### PR TITLE
Update module to match 'oracle-samples'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dsn := `user="scott" password="tiger"
 package main
 
 import (
-        "github.com/oracle/gorm-oracle/oracle"
+        "github.com/oracle-samples/gorm-oracle/oracle"
         "gorm.io/gorm"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oracle/gorm-oracle
+module github.com/oracle-samples/gorm-oracle
 
 go 1.24.4
 

--- a/tests/associations_belongs_to_test.go
+++ b/tests/associations_belongs_to_test.go
@@ -42,7 +42,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/associations_has_many_test.go
+++ b/tests/associations_has_many_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 )

--- a/tests/associations_has_one_test.go
+++ b/tests/associations_has_one_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 )
 
 func TestHasOneAssociation(t *testing.T) {

--- a/tests/associations_many2many_test.go
+++ b/tests/associations_many2many_test.go
@@ -43,7 +43,7 @@ import (
 	"sync"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/associations_test.go
+++ b/tests/associations_test.go
@@ -42,7 +42,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -42,7 +42,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 )
 
 func BenchmarkCreate(b *testing.B) {

--- a/tests/count_test.go
+++ b/tests/count_test.go
@@ -44,7 +44,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -45,7 +45,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"time"
 

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -42,7 +42,7 @@ import (
 	"errors"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/distinct_test.go
+++ b/tests/distinct_test.go
@@ -42,7 +42,7 @@ import (
 	"regexp"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/embedded_struct_test.go
+++ b/tests/embedded_struct_test.go
@@ -47,7 +47,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/generics_test.go
+++ b/tests/generics_test.go
@@ -49,7 +49,7 @@ import (
 	"sync"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,11 +1,11 @@
-module github.com/oracle/gorm-oracle/tests
+module github.com/oracle-samples/gorm-oracle/tests
 
 go 1.24.4
 
 require gorm.io/gorm v1.30.0
 
 require (
-	github.com/oracle/gorm-oracle v0.0.0-00010101000000-000000000000
+	github.com/oracle-samples/gorm-oracle v0.0.1
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/oracle/gorm-oracle => ../
+replace github.com/oracle-samples/gorm-oracle => ../

--- a/tests/gorm_test.go
+++ b/tests/gorm_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/oracle/gorm-oracle/oracle"
+	"github.com/oracle-samples/gorm-oracle/oracle"
 	"gorm.io/gorm"
 )
 

--- a/tests/group_by_test.go
+++ b/tests/group_by_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm/utils/tests"
 )

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -46,7 +46,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/info.go
+++ b/tests/info.go
@@ -45,7 +45,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/oracle/gorm-oracle/oracle"
+	"github.com/oracle-samples/gorm-oracle/oracle"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -44,7 +44,7 @@ import (
 	"sort"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -42,7 +42,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 )
 
 func TestExceptionsWithInvalidSql(t *testing.T) {

--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -50,7 +50,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"github.com/stretchr/testify/assert"
 

--- a/tests/named_polymorphic_test.go
+++ b/tests/named_polymorphic_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 )
 
 type Hamster struct {

--- a/tests/preload_test.go
+++ b/tests/preload_test.go
@@ -49,7 +49,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/prepared_stmt_test.go
+++ b/tests/prepared_stmt_test.go
@@ -45,7 +45,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -51,7 +51,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/scan_test.go
+++ b/tests/scan_test.go
@@ -46,7 +46,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/scanner_valuer_test.go
+++ b/tests/scanner_valuer_test.go
@@ -51,7 +51,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/scopes_test.go
+++ b/tests/scopes_test.go
@@ -42,7 +42,7 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 )

--- a/tests/soft_delete_test.go
+++ b/tests/soft_delete_test.go
@@ -46,7 +46,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm/clause"
 

--- a/tests/sql_builder_test.go
+++ b/tests/sql_builder_test.go
@@ -45,7 +45,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -42,7 +42,7 @@ import (
 	"regexp"
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -45,8 +45,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oracle/gorm-oracle/oracle"
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	"github.com/oracle-samples/gorm-oracle/oracle"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"

--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -45,7 +45,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 )

--- a/tests/update_belongs_to_test.go
+++ b/tests/update_belongs_to_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 )

--- a/tests/update_has_many_test.go
+++ b/tests/update_has_many_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 )

--- a/tests/update_has_one_test.go
+++ b/tests/update_has_one_test.go
@@ -44,7 +44,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/utils/tests"

--- a/tests/update_many2many_test.go
+++ b/tests/update_many2many_test.go
@@ -41,7 +41,7 @@ package tests
 import (
 	"testing"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 )

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -49,7 +49,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -44,7 +44,7 @@ import (
 
 	"time"
 
-	. "github.com/oracle/gorm-oracle/tests/utils"
+	. "github.com/oracle-samples/gorm-oracle/tests/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"


### PR DESCRIPTION
# Description

The module name was 'github.com/oracle/gorm-oracle' which didn't match the current repository 'github.com/oracle-samples/gorm-oracle'. This would cause an error when publishing the go package. 