### PR TITLE
Fix soft delete returning test.

### DIFF
--- a/oracle/delete.go
+++ b/oracle/delete.go
@@ -93,6 +93,22 @@ func Delete(db *gorm.DB) {
 		addPrimaryKeyWhereClause(db)
 	}
 
+	// redirect soft-delete to update clause with bulk returning
+	if stmt.Schema != nil {
+		if deletedAtField := stmt.Schema.LookUpField("deleted_at"); deletedAtField != nil && !stmt.Unscoped {
+			for _, c := range stmt.Schema.DeleteClauses {
+				stmt.AddClause(c)
+			}
+			delete(stmt.Clauses, "DELETE")
+			delete(stmt.Clauses, "FROM")
+			stmt.SQL.Reset()
+			stmt.Vars = stmt.Vars[:0]
+			stmt.AddClauseIfNotExists(clause.Update{})
+			Update(db)
+			return
+		}
+	}
+
 	// This prevents soft deletes from bypassing the safety check
 	checkMissingWhereConditions(db)
 	if db.Error != nil {
@@ -434,25 +450,7 @@ func executeDelete(db *gorm.DB) {
 	_, hasReturning := stmt.Clauses["RETURNING"]
 
 	if hasReturning {
-		// For RETURNING, we need to check if it's a soft delete or hard delete
-		if stmt.Schema != nil {
-			if deletedAtField := stmt.Schema.LookUpField("deleted_at"); deletedAtField != nil && !stmt.Unscoped {
-				// Soft delete with RETURNING - use QueryContext
-				if rows, err := stmt.ConnPool.QueryContext(stmt.Context, stmt.SQL.String(), stmt.Vars...); err == nil {
-					defer rows.Close()
-					gorm.Scan(rows, db, gorm.ScanInitialized)
-
-					if stmt.Result != nil {
-						stmt.Result.RowsAffected = db.RowsAffected
-					}
-				} else {
-					db.AddError(err)
-				}
-				return
-			}
-		}
-
-		// Hard delete with RETURNING - use ExecContext (for PL/SQL blocks)
+		// Hard delete & soft delete with RETURNING - use ExecContext (for PL/SQL blocks)
 		result, err := stmt.ConnPool.ExecContext(stmt.Context, stmt.SQL.String(), stmt.Vars...)
 		if err == nil {
 			db.RowsAffected, _ = result.RowsAffected()

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -248,7 +248,6 @@ func TestDeleteSliceWithAssociations(t *testing.T) {
 
 // only sqlite, postgres, sqlserver support returning
 func TestSoftDeleteReturning(t *testing.T) {
-	t.Skip()
 	users := []*User{
 		GetUser("delete-returning-1", Config{}),
 		GetUser("delete-returning-2", Config{}),
@@ -257,13 +256,13 @@ func TestSoftDeleteReturning(t *testing.T) {
 	DB.Create(&users)
 
 	var results []User
-	DB.Where("name IN ?", []string{users[0].Name, users[1].Name}).Clauses(clause.Returning{}).Delete(&results)
+	DB.Where("\"name\" IN ?", []string{users[0].Name, users[1].Name}).Clauses(clause.Returning{}).Delete(&results)
 	if len(results) != 2 {
 		t.Errorf("failed to return delete data, got %v", results)
 	}
 
 	var count int64
-	DB.Model(&User{}).Where("name IN ?", []string{users[0].Name, users[1].Name, users[2].Name}).Count(&count)
+	DB.Model(&User{}).Where("\"name\" IN ?", []string{users[0].Name, users[1].Name, users[2].Name}).Count(&count)
 	if count != 1 {
 		t.Errorf("failed to delete data, current count %v", count)
 	}

--- a/tests/joins_test.go
+++ b/tests/joins_test.go
@@ -252,8 +252,6 @@ func TestJoinCount(t *testing.T) {
 }
 
 func TestJoinWithSoftDeleted(t *testing.T) {
-	t.Skip()
-
 	user := GetUser("TestJoinWithSoftDeletedUser", Config{Account: true, NamedPet: true})
 	DB.Create(&user)
 

--- a/tests/passed-tests.txt
+++ b/tests/passed-tests.txt
@@ -79,7 +79,7 @@ TestBlockGlobalDelete
 TestDeleteWithAssociations
 TestDeleteAssociationsWithUnscoped
 TestDeleteSliceWithAssociations
-#TestSoftDeleteReturning
+TestSoftDeleteReturning
 TestDeleteReturning
 TestDeleteByPrimaryKeyOnly
 TestHardDeleteAfterSoftDelete


### PR DESCRIPTION
Fix TestSoftDeleteReturning test by adding quoted identifiers and redirecting soft-delete to customised update clause with bulk returning instead of default update and returning clause. QueryContext is removed for soft delete as it is not compatible with update clause.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] TestSoftDeleteReturning

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
