### PR TITLE
Fix records mismatch when doing bulk insert in TestReturningWithNullToZeroValues

### DIFF
--- a/oracle/common.go
+++ b/oracle/common.go
@@ -437,14 +437,12 @@ func writeQuotedIdentifier(builder *strings.Builder, identifier string) {
 //
 // Example output:
 //
-//	DECLARE
-//	  TYPE t_record IS RECORD (
-//	    "id" "users"."id"%TYPE,
-//	    "created_at" "users"."created_at"%TYPE,
-//	    ...
-//	  );
-//	  TYPE t_records IS TABLE OF t_record;
-//	  l_inserted_records t_records;
+//	TYPE t_record IS RECORD (
+//	  "id" "users"."id"%TYPE,
+//	  "created_at" "users"."created_at"%TYPE,
+//	  ...
+//	);
+//	TYPE t_records IS TABLE OF t_record;
 //
 // Parameters:
 //   - plsqlBuilder: The builder to write the PL/SQL code into.

--- a/oracle/create.go
+++ b/oracle/create.go
@@ -285,9 +285,7 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 
 	// Start PL/SQL block
 	plsqlBuilder.WriteString("DECLARE\n")
-	plsqlBuilder.WriteString("  TYPE t_records IS TABLE OF ")
-	writeQuotedIdentifier(&plsqlBuilder, stmt.Table)
-	plsqlBuilder.WriteString("%ROWTYPE;\n")
+	writeTableRecordCollectionDecl(&plsqlBuilder, stmt.Schema.DBNames, stmt.Table)
 	plsqlBuilder.WriteString("  l_affected_records t_records;\n")
 
 	// Create array types and variables for each column
@@ -526,9 +524,7 @@ func buildBulkInsertOnlyPLSQL(db *gorm.DB, createValues clause.Values) {
 
 	// Start PL/SQL block
 	plsqlBuilder.WriteString("DECLARE\n")
-	plsqlBuilder.WriteString("  TYPE t_records IS TABLE OF ")
-	writeQuotedIdentifier(&plsqlBuilder, stmt.Table)
-	plsqlBuilder.WriteString("%ROWTYPE;\n")
+	writeTableRecordCollectionDecl(&plsqlBuilder, stmt.Schema.DBNames, stmt.Table)
 	plsqlBuilder.WriteString("  l_inserted_records t_records;\n")
 
 	// Create array types and variables for each column

--- a/oracle/delete.go
+++ b/oracle/delete.go
@@ -239,9 +239,7 @@ func buildBulkDeletePLSQL(db *gorm.DB) {
 
 	// Start PL/SQL block
 	plsqlBuilder.WriteString("DECLARE\n")
-	plsqlBuilder.WriteString("  TYPE t_records IS TABLE OF ")
-	writeQuotedIdentifier(&plsqlBuilder, stmt.Table)
-	plsqlBuilder.WriteString("%ROWTYPE;\n")
+	writeTableRecordCollectionDecl(&plsqlBuilder, stmt.Schema.DBNames, stmt.Table)
 	plsqlBuilder.WriteString("  l_deleted_records t_records;\n")
 	plsqlBuilder.WriteString("BEGIN\n")
 

--- a/oracle/update.go
+++ b/oracle/update.go
@@ -476,9 +476,7 @@ func buildUpdatePLSQL(db *gorm.DB) {
 
 	// Start PL/SQL block
 	plsqlBuilder.WriteString("DECLARE\n")
-	plsqlBuilder.WriteString("  TYPE t_records IS TABLE OF ")
-	writeQuotedIdentifier(&plsqlBuilder, stmt.Table)
-	plsqlBuilder.WriteString("%ROWTYPE;\n")
+	writeTableRecordCollectionDecl(&plsqlBuilder, stmt.Schema.DBNames, stmt.Table)
 	plsqlBuilder.WriteString("  l_updated_records t_records;\n")
 	plsqlBuilder.WriteString("BEGIN\n")
 

--- a/tests/gorm_test.go
+++ b/tests/gorm_test.go
@@ -54,7 +54,6 @@ func TestOpen(t *testing.T) {
 }
 
 func TestReturningWithNullToZeroValues(t *testing.T) {
-	t.Skip()
 	// This user struct will leverage the existing users table, but override
 	// the Name field to default to null.
 	type user struct {
@@ -72,7 +71,7 @@ func TestReturningWithNullToZeroValues(t *testing.T) {
 	}
 
 	got := user{}
-	results := DB.First(&got, "id = ?", u1.ID)
+	results := DB.First(&got, "\"id\" = ?", u1.ID)
 	if results.Error != nil {
 		t.Fatalf("errors happened on first: %v", results.Error)
 	} else if results.RowsAffected != 1 {
@@ -81,7 +80,7 @@ func TestReturningWithNullToZeroValues(t *testing.T) {
 		t.Fatalf("first expects: %v, got %v", u1, got)
 	}
 
-	results = DB.Select("id, name").Find(&got)
+	results = DB.Select("\"id\", \"name\"").Find(&got)
 	if results.Error != nil {
 		t.Fatalf("errors happened on first: %v", results.Error)
 	} else if results.RowsAffected != 1 {
@@ -112,7 +111,7 @@ func TestReturningWithNullToZeroValues(t *testing.T) {
 	}
 
 	var gotUsers []user
-	results = DB.Where("id in (?, ?)", u1.ID, u2.ID).Order("id asc").Select("id, name").Find(&gotUsers)
+	results = DB.Where("\"id\" in (?, ?)", u1.ID, u2.ID).Order("\"id\" asc").Select("\"id\", \"name\"").Find(&gotUsers)
 	if results.Error != nil {
 		t.Fatalf("errors happened on first: %v", results.Error)
 	} else if results.RowsAffected != 2 {

--- a/tests/passed-tests.txt
+++ b/tests/passed-tests.txt
@@ -124,7 +124,7 @@ TestGenericsReuse
 TestGenericsWithTransaction
 TestGenericsToSQL
 TestOpen
-#TestReturningWithNullToZeroValues
+TestReturningWithNullToZeroValues
 TestGroupBy
 TestRunCallbacks
 TestCallbacksWithErrors


### PR DESCRIPTION
# Description

Fixes `TestReturningWithNullToZeroValues`.

We previously declared the PL/SQL collection as follows:
`TYPE t_records IS TABLE OF "users"%ROWTYPE;`
However, this causes an error when the struct fields represent only a subset of the actual table.
The error is:
`ORA-06550: line 17, column 41: PL/SQL: ORA-00913: too many values`

For example, in TestReturningWithNullToZeroValues, the struct is declared as:
```
type user struct {
	gorm.Model
	Name string `gorm:"default:null"`
}
```

The struct user leverages the existing user table which is declared by the following struct:
```
type User struct {
	gorm.Model
	Name      string
	Age       uint
	Birthday  *time.Time
	Account   Account
	Pets      []*Pet
	NamedPet  *Pet
	Toys      []Toy   `gorm:"polymorphic:Owner"`
	Tools     []Tools `gorm:"polymorphicType:Type;polymorphicId:CustomID"`
	CompanyID *int
	Company   Company
	ManagerID *uint
	Manager   *User
	Team      []User     `gorm:"foreignkey:ManagerID"`
	Languages []Language `gorm:"many2many:UserSpeak;"`
	Friends   []*User    `gorm:"many2many:user_friends;"`
	Active    bool
}
```

To address this mismatch, the function `writeTableRecordCollectionDecl` was added.
It generates a PL/SQL declaration where the record type matches only the fields present in the provided struct, avoiding the too many values error.


Here's an example of the generated PLSQL before the changes:
```sql
DECLARE
  TYPE t_records IS TABLE OF "users"%ROWTYPE;
  l_inserted_records t_records;
  TYPE t_col_0_array IS TABLE OF TIMESTAMP WITH TIME ZONE;
  l_col_0_array t_col_0_array;
  TYPE t_col_1_array IS TABLE OF TIMESTAMP WITH TIME ZONE;
  l_col_1_array t_col_1_array;
  TYPE t_col_2_array IS TABLE OF TIMESTAMP WITH TIME ZONE;
  l_col_2_array t_col_2_array;
BEGIN
  l_col_0_array := t_col_0_array('2025-08-15 11:56:28.247', '2025-08-15 11:56:28.247');
  l_col_1_array := t_col_1_array('2025-08-15 11:56:28.247', '2025-08-15 11:56:28.247');
  l_col_2_array := t_col_2_array(NULL, NULL);
  FORALL i IN 1..2
    INSERT INTO "users" ("created_at", "updated_at", "deleted_at") VALUES (l_col_0_array(i), l_col_1_array(i), l_col_2_array(i))
    RETURNING "id", "created_at", "updated_at", "deleted_at", "name"
    BULK COLLECT INTO l_inserted_records;
    <too long; trimmed>
END;
```

and after the changes:
``` sql
DECLARE
  TYPE t_record IS RECORD (
    "id" "users"."id"%TYPE,
    "created_at" "users"."created_at"%TYPE,
    "updated_at" "users"."updated_at"%TYPE,
    "deleted_at" "users"."deleted_at"%TYPE,
    "name" "users"."name"%TYPE
  );
  TYPE t_records IS TABLE OF t_record;
  l_inserted_records t_records;
  TYPE t_col_0_array IS TABLE OF TIMESTAMP WITH TIME ZONE;
  l_col_0_array t_col_0_array;
  TYPE t_col_1_array IS TABLE OF TIMESTAMP WITH TIME ZONE;
  l_col_1_array t_col_1_array;
  TYPE t_col_2_array IS TABLE OF TIMESTAMP WITH TIME ZONE;
  l_col_2_array t_col_2_array;
BEGIN
  l_col_0_array := t_col_0_array('2025-08-19 10:54:12.584', '2025-08-19 10:54:12.584');
  l_col_1_array := t_col_1_array('2025-08-19 10:54:12.584', '2025-08-19 10:54:12.584');
  l_col_2_array := t_col_2_array(NULL, NULL);
  FORALL i IN 1..2
    INSERT INTO "users" ("created_at", "updated_at", "deleted_at") VALUES (l_col_0_array(i), l_col_1_array(i), l_col_2_array(i))
    RETURNING "id", "created_at", "updated_at", "deleted_at", "name"
    BULK COLLECT INTO l_inserted_records;
    <too long; trimmed>
END;
```

## Type of change

Please delete options that are not relevant.

- [v] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update