### PR TITLE
Fix generics test

### DIFF
--- a/tests/generics_test.go
+++ b/tests/generics_test.go
@@ -632,7 +632,6 @@ func TestGenericsPreloads(t *testing.T) {
 }
 
 func TestGenericsNestedPreloads(t *testing.T) {
-	t.Skip()
 	user := *GetUser("generics_nested_preload", Config{Pets: 2})
 	user.Friends = []*User{GetUser("generics_nested_preload", Config{Pets: 5})}
 
@@ -659,6 +658,14 @@ func TestGenericsNestedPreloads(t *testing.T) {
 	}
 
 	user3, err := db.Preload("Pets.Toy", nil).Preload("Friends.Pets", func(db gorm.PreloadBuilder) error {
+		db.Select(
+			"pets.id",
+			"pets.created_at",
+			"pets.updated_at",
+			"pets.deleted_at",
+			"pets.user_id",
+			"pets.name",
+		)
 		db.LimitPerRecord(3)
 		return nil
 	}).Where(user.ID).Take(ctx)

--- a/tests/generics_test.go
+++ b/tests/generics_test.go
@@ -150,7 +150,7 @@ func TestGenericsCreateInBatches(t *testing.T) {
 }
 
 func TestGenericsExecAndUpdate(t *testing.T) {
-	t.Skip()
+	t.Skip("temporarily skiped: covered by PR#26; unskip after merge")
 	ctx := context.Background()
 
 	name := "GenericsExec"
@@ -158,7 +158,7 @@ func TestGenericsExecAndUpdate(t *testing.T) {
 		t.Fatalf("Exec insert failed: %v", err)
 	}
 
-	u, err := gorm.G[User](DB).Table("\"users\" u").Where("u.name = ?", name).First(ctx)
+	u, err := gorm.G[User](DB).Table("\"users\" \"u\"").Where("\"u\".\"name\" = ?", name).First(ctx)
 	if err != nil {
 		t.Fatalf("failed to find user, got error: %v", err)
 	} else if u.Name != name || u.ID == 0 {
@@ -321,7 +321,6 @@ func TestGenericsScopes(t *testing.T) {
 }
 
 func TestGenericsJoins(t *testing.T) {
-	t.Skip()
 	ctx := context.Background()
 	db := gorm.G[User](DB)
 
@@ -332,7 +331,7 @@ func TestGenericsJoins(t *testing.T) {
 
 	// Inner JOIN + WHERE
 	result, err := db.Joins(clause.Has("Company"), func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
-		db.Where("?.name = ?", joinTable, u.Company.Name)
+		db.Where("?.\"name\" = ?", joinTable, u.Company.Name)
 		return nil
 	}).First(ctx)
 	if err != nil {
@@ -368,7 +367,7 @@ func TestGenericsJoins(t *testing.T) {
 		if joinTable.Name != "t" {
 			t.Fatalf("Join table should be t, but got %v", joinTable.Name)
 		}
-		db.Where("?.name = ?", joinTable, u.Company.Name)
+		db.Where("?.\"name\" = ?", joinTable, u.Company.Name)
 		return nil
 	}).Where(map[string]any{"name": u.Name}).First(ctx)
 	if err != nil {
@@ -378,13 +377,14 @@ func TestGenericsJoins(t *testing.T) {
 		t.Fatalf("Joins expected %s, got %+v", u.Name, result)
 	}
 
+	// TODO: Temporarily disale due to issue with As("t")
 	// Raw Subquery JOIN + WHERE
-	result, err = db.Joins(clause.LeftJoin.AssociationFrom("Company", gorm.G[Company](DB)).As("t"),
+	/*result, err = db.Joins(clause.LeftJoin.AssociationFrom("Company", gorm.G[Company](DB)).As("t"),
 		func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
 			if joinTable.Name != "t" {
 				t.Fatalf("Join table should be t, but got %v", joinTable.Name)
 			}
-			db.Where("?.name = ?", joinTable, u.Company.Name)
+			db.Where("?.\"name\" = ?", joinTable, u.Company.Name)
 			return nil
 		},
 	).Where(map[string]any{"name": u2.Name}).First(ctx)
@@ -393,15 +393,15 @@ func TestGenericsJoins(t *testing.T) {
 	}
 	if result.Name != u2.Name || result.Company.Name != u.Company.Name || result.Company.ID == 0 {
 		t.Fatalf("Joins expected %s, got %+v", u.Name, result)
-	}
+	}*/
 
 	// Raw Subquery JOIN + WHERE + Select
-	result, err = db.Joins(clause.LeftJoin.AssociationFrom("Company", gorm.G[Company](DB).Select("Name")).As("t"),
+	/*result, err = db.Joins(clause.LeftJoin.AssociationFrom("Company", gorm.G[Company](DB).Select("Name")).As("t"),
 		func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
 			if joinTable.Name != "t" {
 				t.Fatalf("Join table should be t, but got %v", joinTable.Name)
 			}
-			db.Where("?.name = ?", joinTable, u.Company.Name)
+			db.Where("?.\"name\" = ?", joinTable, u.Company.Name)
 			return nil
 		},
 	).Where(map[string]any{"name": u2.Name}).First(ctx)
@@ -410,7 +410,7 @@ func TestGenericsJoins(t *testing.T) {
 	}
 	if result.Name != u2.Name || result.Company.Name != u.Company.Name || result.Company.ID != 0 {
 		t.Fatalf("Joins expected %s, got %+v", u.Name, result)
-	}
+	}*/
 
 	_, err = db.Joins(clause.Has("Company"), func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
 		return errors.New("join error")

--- a/tests/generics_test.go
+++ b/tests/generics_test.go
@@ -56,7 +56,6 @@ import (
 )
 
 func TestGenericsCreate(t *testing.T) {
-	t.Skip()
 	ctx := context.Background()
 
 	user := User{Name: "TestGenericsCreate", Age: 18}
@@ -68,25 +67,25 @@ func TestGenericsCreate(t *testing.T) {
 		t.Fatalf("no primary key found for %v", user)
 	}
 
-	if u, err := gorm.G[User](DB).Where("name = ?", user.Name).First(ctx); err != nil {
+	if u, err := gorm.G[User](DB).Where(`"name" = ?`, user.Name).First(ctx); err != nil {
 		t.Fatalf("failed to find user, got error: %v", err)
 	} else if u.Name != user.Name || u.ID != user.ID {
 		t.Errorf("found invalid user, got %v, expect %v", u, user)
 	}
 
-	if u, err := gorm.G[User](DB).Where("name = ?", user.Name).Take(ctx); err != nil {
+	if u, err := gorm.G[User](DB).Where(`"name" = ?`, user.Name).Take(ctx); err != nil {
 		t.Fatalf("failed to find user, got error: %v", err)
 	} else if u.Name != user.Name || u.ID != user.ID {
 		t.Errorf("found invalid user, got %v, expect %v", u, user)
 	}
 
-	if u, err := gorm.G[User](DB).Select("name").Where("name = ?", user.Name).First(ctx); err != nil {
+	if u, err := gorm.G[User](DB).Select("name").Where(`"name" = ?`, user.Name).First(ctx); err != nil {
 		t.Fatalf("failed to find user, got error: %v", err)
 	} else if u.Name != user.Name || u.Age != 0 {
 		t.Errorf("found invalid user, got %v, expect %v", u, user)
 	}
 
-	if u, err := gorm.G[User](DB).Omit("name").Where("name = ?", user.Name).First(ctx); err != nil {
+	if u, err := gorm.G[User](DB).Omit("name").Where(`"name" = ?`, user.Name).First(ctx); err != nil {
 		t.Fatalf("failed to find user, got error: %v", err)
 	} else if u.Name != "" || u.Age != user.Age {
 		t.Errorf("found invalid user, got %v, expect %v", u, user)
@@ -96,13 +95,13 @@ func TestGenericsCreate(t *testing.T) {
 		ID   int
 		Name string
 	}{}
-	if err := gorm.G[User](DB).Where("name = ?", user.Name).Scan(ctx, &result); err != nil {
+	if err := gorm.G[User](DB).Where(`"name" = ?`, user.Name).Scan(ctx, &result); err != nil {
 		t.Fatalf("failed to scan user, got error: %v", err)
 	} else if result.Name != user.Name || uint(result.ID) != user.ID {
 		t.Errorf("found invalid user, got %v, expect %v", result, user)
 	}
 
-	mapResult, err := gorm.G[map[string]interface{}](DB).Table("users").Where("name = ?", user.Name).MapColumns(map[string]string{"name": "user_name"}).Take(ctx)
+	mapResult, err := gorm.G[map[string]interface{}](DB).Table("users").Where(`"name" = ?`, user.Name).MapColumns(map[string]string{"name": "user_name"}).Take(ctx)
 	if v := mapResult["user_name"]; fmt.Sprint(v) != user.Name {
 		t.Errorf("failed to find map results, got %v, err %v", mapResult, err)
 	}

--- a/tests/passed-tests.txt
+++ b/tests/passed-tests.txt
@@ -104,7 +104,7 @@ TestEmbeddedTagSetting
 TestDialectorWithErrorTranslatorSupport
 TestSupportedDialectorWithErrDuplicatedKey
 TestSupportedDialectorWithErrForeignKeyViolated
-#TestGenericsCreate
+TestGenericsCreate
 TestGenericsCreateInBatches
 #TestGenericsExecAndUpdate
 TestGenericsRow
@@ -113,7 +113,7 @@ TestGenericsFindInBatches
 TestGenericsScopes
 #TestGenericsJoins
 TestGenericsNestedJoins
-#TestGenericsPreloads
+TestGenericsPreloads
 #TestGenericsNestedPreloads
 TestGenericsDistinct
 TestGenericsGroupHaving

--- a/tests/passed-tests.txt
+++ b/tests/passed-tests.txt
@@ -114,7 +114,7 @@ TestGenericsScopes
 #TestGenericsJoins
 TestGenericsNestedJoins
 TestGenericsPreloads
-#TestGenericsNestedPreloads
+TestGenericsNestedPreloads
 TestGenericsDistinct
 TestGenericsGroupHaving
 TestGenericsSubQuery


### PR DESCRIPTION
Fix test/generics_test

- TestGenericsCreate
- TestGenericsPreloads
- TestGenericsNestedPreloads

TestGenericsExecAndUpdate - temporarily skiped (covered by [PR#26](https://github.com/oracle-samples/gorm-oracle/pull/26)), will unskip after merge
TestGenericsJoins - partially comment out, please see tracking issue: https://github.com/oracle-samples/gorm-oracle/issues/33
