### PR TITLE
Query tests

### DIFF
--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -959,16 +959,15 @@ func TestPluckWithSelect(t *testing.T) {
 }
 
 func TestSelectWithVariables(t *testing.T) {
-	t.Skip()
 	DB.Save(&User{Name: "select_with_variables"})
 
-	rows, _ := DB.Table("users").Where("name = ?", "select_with_variables").Select("? as fake", gorm.Expr("name")).Rows()
+	rows, _ := DB.Table("users").Where("\"name\" = ?", "select_with_variables").Select("? as fake", gorm.Expr("\"name\"")).Rows()
 
 	if !rows.Next() {
 		t.Errorf("Should have returned at least one row")
 	} else {
 		columns, _ := rows.Columns()
-		tests.AssertEqual(t, columns, []string{"fake"})
+		tests.AssertEqual(t, columns, []string{"FAKE"})
 	}
 
 	rows.Close()


### PR DESCRIPTION
For TestFind, when gorm scans into map[string]interface{}, there’s no type info for each column. Unlike the underlying drivers for postgres and others that use int64 for their numerical values, godror uses godror.NUMBER type. that's why it comes back as a string. 

For TestPluck, the issue is a bit similar in that the custom scanner expects the value that comes from godror to be int64 but it's actually godror.NUMBER.