### PR TITLE
Fix TestMigrateConstraint test

### DIFF
--- a/tests/migrate_test.go
+++ b/tests/migrate_test.go
@@ -582,9 +582,8 @@ func TestMigrateColumns(t *testing.T) {
 }
 
 func TestMigrateConstraint(t *testing.T) {
-	t.Skip()
 
-	names := []string{"Account", "fk_users_account", "Pets", "fk_users_pets", "Company", "fk_users_company", "Team", "fk_users_team", "Languages", "fk_users_languages"}
+	names := []string{"Account", "fk_users_account", "Pets", "fk_users_pets", "Company", "fk_users_company", "Team", "fk_users_team"}
 
 	for _, name := range names {
 		if !DB.Migrator().HasConstraint(&User{}, name) {


### PR DESCRIPTION
### Problem
The `TestMigrateConstraint` test fails on Oracle with the following error:
ALTER TABLE "user_speaks" ADD CONSTRAINT "fk_users_languages" FOREIGN KEY ("user_id") REFERENCES "users"("id") ORA-02275: such a referential constraint already exists in the table

This happens because Oracle already creates a foreign key on `user_speaks.user_id → users.id`
(named `fk_user_speaks_user`). Oracle does not allow creating another foreign key with the same
definition but a different name (`fk_users_languages`).

### Fix 
Removed `"Languages", "fk_users_languages"` from the test list in `TestMigrateConstraint`. - This avoids attempting to create a duplicate foreign key that Oracle rejects.