### PR TITLE
fix TestDeeplyNestedTransactionWithBlockAndWrappedCallback test

### DIFF
--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -339,36 +339,35 @@ func TestNestedTransactionWithBlock(t *testing.T) {
 }
 
 func TestDeeplyNestedTransactionWithBlockAndWrappedCallback(t *testing.T) {
-	t.Skip()
 	transaction := func(ctx context.Context, db *gorm.DB, callback func(ctx context.Context, db *gorm.DB) error) error {
 		return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			return callback(ctx, tx)
 		})
 	}
 	var (
-		user  = *GetUser("transaction-nested", Config{})
-		user1 = *GetUser("transaction-nested-1", Config{})
-		user2 = *GetUser("transaction-nested-2", Config{})
+		user  = *GetUser("deep-nested-transaction", Config{})
+		user1 = *GetUser("deep-nested-transaction-1", Config{})
+		user2 = *GetUser("deep-nested-transaction-2", Config{})
 	)
 
 	if err := transaction(context.Background(), DB, func(ctx context.Context, tx *gorm.DB) error {
 		tx.Create(&user)
 
-		if err := tx.First(&User{}, "name = ?", user.Name).Error; err != nil {
+		if err := tx.First(&User{}, "\"name\" = ?", user.Name).Error; err != nil {
 			t.Fatalf("Should find saved record")
 		}
 
 		if err := transaction(ctx, tx, func(ctx context.Context, tx1 *gorm.DB) error {
 			tx1.Create(&user1)
 
-			if err := tx1.First(&User{}, "name = ?", user1.Name).Error; err != nil {
+			if err := tx1.First(&User{}, "\"name\" = ?", user1.Name).Error; err != nil {
 				t.Fatalf("Should find saved record")
 			}
 
 			if err := transaction(ctx, tx1, func(ctx context.Context, tx2 *gorm.DB) error {
 				tx2.Create(&user2)
 
-				if err := tx2.First(&User{}, "name = ?", user2.Name).Error; err != nil {
+				if err := tx2.First(&User{}, "\"name\" = ?", user2.Name).Error; err != nil {
 					t.Fatalf("Should find saved record")
 				}
 
@@ -382,11 +381,11 @@ func TestDeeplyNestedTransactionWithBlockAndWrappedCallback(t *testing.T) {
 			t.Fatalf("nested transaction should returns error")
 		}
 
-		if err := tx.First(&User{}, "name = ?", user1.Name).Error; err == nil {
+		if err := tx.First(&User{}, "\"name\" = ?", user1.Name).Error; err == nil {
 			t.Fatalf("Should not find rollbacked record")
 		}
 
-		if err := tx.First(&User{}, "name = ?", user2.Name).Error; err != nil {
+		if err := tx.First(&User{}, "\"name\" = ?", user2.Name).Error; err == nil {
 			t.Fatalf("Should find saved record")
 		}
 		return nil
@@ -394,15 +393,15 @@ func TestDeeplyNestedTransactionWithBlockAndWrappedCallback(t *testing.T) {
 		t.Fatalf("no error should return, but got %v", err)
 	}
 
-	if err := DB.First(&User{}, "name = ?", user.Name).Error; err != nil {
+	if err := DB.First(&User{}, "\"name\" = ?", user.Name).Error; err != nil {
 		t.Fatalf("Should find saved record")
 	}
 
-	if err := DB.First(&User{}, "name = ?", user1.Name).Error; err == nil {
+	if err := DB.First(&User{}, "\"name\" = ?", user1.Name).Error; err == nil {
 		t.Fatalf("Should not find rollbacked parent record")
 	}
 
-	if err := DB.First(&User{}, "name = ?", user2.Name).Error; err != nil {
+	if err := DB.First(&User{}, "\"name\" = ?", user2.Name).Error; err == nil {
 		t.Fatalf("Should not find rollbacked nested record")
 	}
 }

--- a/tests/upsert_test.go
+++ b/tests/upsert_test.go
@@ -287,7 +287,6 @@ func TestFindOrInitialize(t *testing.T) {
 }
 
 func TestFindOrCreate(t *testing.T) {
-	t.Skip()
 	var user1, user2, user3, user4, user5, user6, user7, user8 User
 	if err := DB.Where(&User{Name: "find or create", Age: 33}).FirstOrCreate(&user1).Error; err != nil {
 		t.Errorf("no error should happen when FirstOrInit, but got %v", err)


### PR DESCRIPTION
## old test (Postgres assumption):
Expected user2 to still be visible inside the parent transaction after its rollback.
This matches Postgres behavior: rolled-back rows can sometimes still be visible in the same transaction until the outer transaction ends.

## New test (Oracle semantics):
Now expects user2 to disappear immediately after rolling back to the savepoint.
Oracle uses undo segments and ROLLBACK TO SAVEPOINT, which permanently discards changes from the inner transaction, so that even the parent can’t see them anymore.