### PR TITLE
Add support for 'OnUpdate'

### DIFF
--- a/oracle/common.go
+++ b/oracle/common.go
@@ -424,6 +424,12 @@ func writeQuotedIdentifier(builder *strings.Builder, identifier string) {
 	builder.WriteByte('"')
 }
 
+func QuoteIdentifier(identifier string) string {
+	var builder strings.Builder
+	writeQuotedIdentifier(&builder, identifier)
+	return builder.String()
+}
+
 // writeTableRecordCollectionDecl writes the PL/SQL declarations needed to
 // define a custom record type and a collection of that record type,
 // based on the schema of the given table.

--- a/tests/associations_test.go
+++ b/tests/associations_test.go
@@ -112,7 +112,6 @@ func TestAssociationNotNullClear(t *testing.T) {
 }
 
 func TestForeignKeyConstraints(t *testing.T) {
-	t.Skip()
 	type Profile struct {
 		ID       uint
 		Name     string
@@ -121,7 +120,7 @@ func TestForeignKeyConstraints(t *testing.T) {
 
 	type Member struct {
 		ID      uint
-		Refer   uint `gorm:"uniqueIndex"`
+		Refer   uint `gorm:"unique"`
 		Name    string
 		Profile Profile `gorm:"Constraint:OnUpdate:CASCADE,OnDelete:CASCADE;FOREIGNKEY:MemberID;References:Refer"`
 	}
@@ -168,11 +167,10 @@ func TestForeignKeyConstraints(t *testing.T) {
 }
 
 func TestForeignKeyConstraintsBelongsTo(t *testing.T) {
-	t.Skip()
 	type Profile struct {
 		ID    uint
 		Name  string
-		Refer uint `gorm:"uniqueIndex"`
+		Refer uint `gorm:"unique"`
 	}
 
 	type Member struct {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,7 +5,8 @@ go 1.24.4
 require gorm.io/gorm v1.30.0
 
 require (
-	github.com/oracle-samples/gorm-oracle v0.0.1
+	github.com/godror/godror v0.49.0
+	github.com/oracle-samples/gorm-oracle v0.1.0
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -13,7 +14,6 @@ require (
 	github.com/VictoriaMetrics/easyproto v0.1.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
-	github.com/godror/godror v0.49.0 // indirect
 	github.com/godror/knownpb v0.3.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect


### PR DESCRIPTION
# Description

Fixes `TestForeignKeyConstraints` and `TestForeignKeyConstraintsBelongsTo`.

1. **Change the tag from `uniqueIndex` to `unique`**

Oracle does not treat a unique index the same as a unique constraint.
When a column is tagged with uniqueIndex, GORM generates a unique index, but foreign key constraints in Oracle require the referenced column to be backed by a unique constraint.

For example, given the following structs:
```go
	type Profile struct {
		ID       uint
		Name     string
		MemberID uint
	}

	type Member struct {
		ID      uint
		Refer   uint `gorm:"uniqueIndex"`
		Name    string
		Profile Profile `gorm:"Constraint:OnUpdate:CASCADE,OnDelete:CASCADE;FOREIGNKEY:MemberID;References:Refer"`
	}
```
the generated SQL is:

```sql
CREATE TABLE "members" ("id" NUMBER(20) GENERATED BY DEFAULT AS IDENTITY,"refer" NUMBER(20),"name" VARCHAR2(4000),PRIMARY KEY ("id"))

CREATE TABLE "profiles" ("id" NUMBER(20) GENERATED BY DEFAULT AS IDENTITY,"name" VARCHAR2(4000),"member_id" NUMBER(20),PRIMARY KEY ("id"),CONSTRAINT "fk_members_profile" FOREIGN KEY ("member_id") REFERENCES "members"("refer") ON DELETE CASCADE)
```

Which fails with:
ORA-02270: no matching unique or primary key for this column-list

Changing the tag to unique generates the correct SQL:

```sql
CREATE TABLE "members" ("id" NUMBER(20) GENERATED BY DEFAULT AS IDENTITY,"refer" NUMBER(20),"name" VARCHAR2(4000),PRIMARY KEY ("id"),CONSTRAINT "uni_members_refer" UNIQUE ("refer"));

CREATE TABLE "profiles" ("id" NUMBER(20) GENERATED BY DEFAULT AS IDENTITY,"name" VARCHAR2(4000),"member_id" NUMBER(20),PRIMARY KEY ("id"),CONSTRAINT "fk_members_profile" FOREIGN KEY ("member_id") REFERENCES "members"("refer") ON DELETE CASCADE)
```

2. **Support `OnUpdate`**

Unlike other databases, Oracle does not directly support the `ON UPDATE` foreign key constraint. To work around this, the driver generates a trigger that simulates the `ON UPDATE` behavior. When a constraint is tagged with `OnUpdate`, the driver skips generating the unsupported SQL and instead creates a trigger that cascades updates whenever the referenced column in the parent table changes.

The trigger is automatically dropped when the table is dropped or when `DropConstraint()` is called.

Added a test `TestMigrateOnUpdateConstraint` to verify this feature.