### PR TITLE
Add support for nil pointer uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.4
 
 require (
 	github.com/godror/godror v0.49.3
+	github.com/google/uuid v1.6.0
 	gorm.io/datatypes v1.2.6
 	gorm.io/gorm v1.31.0
 )
@@ -14,7 +15,6 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/godror/knownpb v0.3.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect

--- a/oracle/query.go
+++ b/oracle/query.go
@@ -39,9 +39,10 @@
 package oracle
 
 import (
-	"gorm.io/gorm"
 	"regexp"
 	"strings"
+
+	"gorm.io/gorm"
 )
 
 // Identifies the table name alias provided as
@@ -63,5 +64,4 @@ func BeforeQuery(db *gorm.DB) {
 			}
 		}
 	}
-	return
 }

--- a/tests/json_bulk_test.go
+++ b/tests/json_bulk_test.go
@@ -50,9 +50,10 @@ import (
 
 func TestBasicCRUD_JSONText(t *testing.T) {
 	type JsonRecord struct {
-		ID         uint           `gorm:"primaryKey;autoIncrement;column:record_id"`
-		Name       string         `gorm:"column:name"`
-		Properties datatypes.JSON `gorm:"column:properties"`
+		ID            uint            `gorm:"primaryKey;autoIncrement;column:record_id"`
+		Name          string          `gorm:"column:name"`
+		Properties    datatypes.JSON  `gorm:"column:properties"`
+		PropertiesPtr *datatypes.JSON `gorm:"column:propertiesPtr"`
 	}
 
 	DB.Migrator().DropTable(&JsonRecord{})
@@ -61,9 +62,11 @@ func TestBasicCRUD_JSONText(t *testing.T) {
 	}
 
 	// INSERT
+	json := datatypes.JSON([]byte(`{"env":"prod","owner":"team-x"}`))
 	rec := JsonRecord{
-		Name:       "json-text",
-		Properties: datatypes.JSON([]byte(`{"env":"prod","owner":"team-x"}`)),
+		Name:          "json-text",
+		Properties:    json,
+		PropertiesPtr: &json,
 	}
 	if err := DB.Create(&rec).Error; err != nil {
 		t.Fatalf("create failed: %v", err)
@@ -73,6 +76,7 @@ func TestBasicCRUD_JSONText(t *testing.T) {
 	}
 
 	// UPDATE (with RETURNING)
+	updateJson := datatypes.JSON([]byte(`{"env":"staging","owner":"team-y","flag":true}`))
 	var ret JsonRecord
 	if err := DB.
 		Clauses(clause.Returning{
@@ -80,13 +84,15 @@ func TestBasicCRUD_JSONText(t *testing.T) {
 				{Name: "record_id"},
 				{Name: "name"},
 				{Name: "properties"},
+				{Name: "propertiesPtr"},
 			},
 		}).
 		Model(&ret).
 		Where("\"record_id\" = ?", rec.ID).
 		Updates(map[string]any{
-			"name":       "json-text-upd",
-			"properties": datatypes.JSON([]byte(`{"env":"staging","owner":"team-y","flag":true}`)),
+			"name":          "json-text-upd",
+			"properties":    updateJson,
+			"propertiesPtr": &updateJson,
 		}).Error; err != nil {
 		t.Fatalf("update returning failed: %v", err)
 	}
@@ -103,6 +109,7 @@ func TestBasicCRUD_JSONText(t *testing.T) {
 				{Name: "record_id"},
 				{Name: "name"},
 				{Name: "properties"},
+				{Name: "propertiesPtr"},
 			},
 		}).
 		Delete(&deleted).Error; err != nil {
@@ -122,9 +129,10 @@ func TestBasicCRUD_JSONText(t *testing.T) {
 
 func TestBasicCRUD_RawMessage(t *testing.T) {
 	type RawRecord struct {
-		ID         uint            `gorm:"primaryKey;autoIncrement;column:record_id"`
-		Name       string          `gorm:"column:name"`
-		Properties json.RawMessage `gorm:"column:properties"`
+		ID            uint             `gorm:"primaryKey;autoIncrement;column:record_id"`
+		Name          string           `gorm:"column:name"`
+		Properties    json.RawMessage  `gorm:"column:properties"`
+		PropertiesPtr *json.RawMessage `gorm:"column:propertiesPtr"`
 	}
 
 	DB.Migrator().DropTable(&RawRecord{})
@@ -132,10 +140,12 @@ func TestBasicCRUD_RawMessage(t *testing.T) {
 		t.Fatalf("migrate failed: %v", err)
 	}
 
+	rawMsg := json.RawMessage(`{"a":1,"b":"x"}`)
 	// INSERT
 	rec := RawRecord{
-		Name:       "raw-json",
-		Properties: json.RawMessage(`{"a":1,"b":"x"}`),
+		Name:          "raw-json",
+		Properties:    rawMsg,
+		PropertiesPtr: &rawMsg,
 	}
 	if err := DB.Create(&rec).Error; err != nil {
 		t.Fatalf("create failed: %v", err)
@@ -145,6 +155,7 @@ func TestBasicCRUD_RawMessage(t *testing.T) {
 	}
 
 	// UPDATE (with RETURNING)
+	upatedRawMsg := json.RawMessage(`{"a":2,"c":true}`)
 	var ret RawRecord
 	if err := DB.
 		Clauses(clause.Returning{
@@ -152,17 +163,22 @@ func TestBasicCRUD_RawMessage(t *testing.T) {
 				{Name: "record_id"},
 				{Name: "name"},
 				{Name: "properties"},
+				{Name: "propertiesPtr"},
 			},
 		}).
 		Model(&ret).
 		Where("\"record_id\" = ?", rec.ID).
 		Updates(map[string]any{
-			"name":       "raw-json-upd",
-			"properties": json.RawMessage(`{"a":2,"c":true}`),
+			"name":          "raw-json-upd",
+			"properties":    upatedRawMsg,
+			"propertiesPtr": &upatedRawMsg,
 		}).Error; err != nil {
 		t.Fatalf("update returning failed: %v", err)
 	}
-	if ret.ID != rec.ID || ret.Name != "raw-json-upd" || len(ret.Properties) == 0 {
+	if ret.ID != rec.ID ||
+		ret.Name != "raw-json-upd" ||
+		len(ret.Properties) == 0 ||
+		ret.PropertiesPtr == nil || (ret.PropertiesPtr != nil && len(*ret.PropertiesPtr) == 0) {
 		t.Fatalf("unexpected returning row: %#v", ret)
 	}
 
@@ -175,6 +191,7 @@ func TestBasicCRUD_RawMessage(t *testing.T) {
 				{Name: "record_id"},
 				{Name: "name"},
 				{Name: "properties"},
+				{Name: "propertiesPtr"},
 			},
 		}).
 		Delete(&deleted).Error; err != nil {


### PR DESCRIPTION
Incorporate the changes from [joboon:InsertNilUUIDAsNull](https://github.com/oracle-samples/gorm-oracle/compare/main...joboon:gorm-oracle:InsertNilUUIDAsNull).
When inserting a nil of *uuid.UUID objects type, godror serialize the object into the zero-value for uuid.UUIDs ("00000000-0000-0000-0000-000000000000"). Instead, the object should be stored as a NULL.

This PR also added the support of *json.RawMessage.