### PR TITLE
Joboon fix plsql auto increment

### DIFF
--- a/oracle/clause_builder.go
+++ b/oracle/clause_builder.go
@@ -503,6 +503,8 @@ func shouldIncludeColumn(stmt *gorm.Statement, columnName string) bool {
 		stmt.Schema.PrioritizedPrimaryField.AutoIncrement &&
 		stmt.Schema.PrioritizedPrimaryField.DBName == columnName {
 		return false
+	} else if stmt.Schema.LookUpField(columnName).AutoIncrement {
+		return false
 	}
 	return true
 }

--- a/oracle/delete.go
+++ b/oracle/delete.go
@@ -299,14 +299,14 @@ func buildBulkDeletePLSQL(db *gorm.DB) {
 							"  IF l_deleted_records.COUNT > %d THEN :%d := l_deleted_records(%d).",
 							rowIdx, outParamIndex+1, rowIdx+1,
 						))
-						writeQuotedIdentifier(&plsqlBuilder, column)
+						db.QuoteTo(&plsqlBuilder, column)
 						plsqlBuilder.WriteString("; END IF;\n")
 					} else {
 						// JSON -> text bind
 						stmt.Vars = append(stmt.Vars, sql.Out{Dest: new(string)})
 						plsqlBuilder.WriteString(fmt.Sprintf("  IF l_deleted_records.COUNT > %d THEN\n", rowIdx))
 						plsqlBuilder.WriteString(fmt.Sprintf("    :%d := JSON_SERIALIZE(l_deleted_records(%d).", outParamIndex+1, rowIdx+1))
-						writeQuotedIdentifier(&plsqlBuilder, column)
+						db.QuoteTo(&plsqlBuilder, column)
 						plsqlBuilder.WriteString(" RETURNING CLOB);\n")
 						plsqlBuilder.WriteString("  END IF;\n")
 					}
@@ -316,7 +316,7 @@ func buildBulkDeletePLSQL(db *gorm.DB) {
 					stmt.Vars = append(stmt.Vars, sql.Out{Dest: dest})
 					plsqlBuilder.WriteString(fmt.Sprintf("  IF l_deleted_records.COUNT > %d THEN\n", rowIdx))
 					plsqlBuilder.WriteString(fmt.Sprintf("    :%d := l_deleted_records(%d).", outParamIndex+1, rowIdx+1))
-					writeQuotedIdentifier(&plsqlBuilder, column)
+					db.QuoteTo(&plsqlBuilder, column)
 					plsqlBuilder.WriteString(";\n")
 					plsqlBuilder.WriteString("  END IF;\n")
 				}

--- a/oracle/update.go
+++ b/oracle/update.go
@@ -572,17 +572,17 @@ func buildUpdatePLSQL(db *gorm.DB) {
 				if isJSONField(field) {
 					if isRawMessageField(field) {
 						plsqlBuilder.WriteString(fmt.Sprintf("l_updated_records(%d).", rowIdx+1))
-						writeQuotedIdentifier(&plsqlBuilder, column)
+						db.QuoteTo(&plsqlBuilder, column)
 					} else {
 						// serialize JSON so it binds as text
 						plsqlBuilder.WriteString("JSON_SERIALIZE(")
 						plsqlBuilder.WriteString(fmt.Sprintf("l_updated_records(%d).", rowIdx+1))
-						writeQuotedIdentifier(&plsqlBuilder, column)
+						db.QuoteTo(&plsqlBuilder, column)
 						plsqlBuilder.WriteString(" RETURNING CLOB)")
 					}
 				} else {
 					plsqlBuilder.WriteString(fmt.Sprintf("l_updated_records(%d).", rowIdx+1))
-					writeQuotedIdentifier(&plsqlBuilder, column)
+					db.QuoteTo(&plsqlBuilder, column)
 				}
 
 				plsqlBuilder.WriteString("; END IF;\n")

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -39,20 +39,83 @@
 package tests
 
 import (
+	"errors"
 	"regexp"
+	"sort"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/oracle-samples/gorm-oracle/oracle"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/utils/tests"
 )
 
-type Student struct {
-	ID   uint
-	Name string
+type FolderData struct {
+	ID         string           `gorm:"primaryKey;column:folder_id"`
+	Name       string           `gorm:"column:folder_nm"`
+	Properties []FolderProperty `gorm:"foreignKey:ID;PRELOAD:false"`
 }
 
-func (s Student) TableName() string {
-	return "STUDENTS"
+func (FolderData) TableName() string {
+	return "folder_data"
+}
+
+type FolderProperty struct {
+	Seq   uint64 `gorm:"autoIncrement"`
+	ID    string `gorm:"primaryKey;column:folder_id"`
+	Key   string `gorm:"primaryKey;unique"`
+	Value string
+}
+
+func (FolderProperty) TableName() string {
+	return "folder_property"
+}
+
+func TestSkipQuoteIdentifiersMigrator(t *testing.T) {
+	db, err := openTestDBWithOptions(
+		&oracle.Config{SkipQuoteIdentifiers: true},
+		&gorm.Config{Logger: newLogger})
+	if err != nil {
+		t.Fatalf("failed to connect database, got error %v", err)
+	}
+
+	db.Migrator().DropTable(&FolderData{}, &FolderProperty{})
+	db.Migrator().CreateTable(&FolderData{}, &FolderProperty{})
+
+	folderDataTN := "FOLDER_DATA"
+	if !db.Migrator().HasTable(folderDataTN) {
+		t.Errorf("Failed to get table: %s", folderDataTN)
+	}
+
+	if !db.Migrator().HasColumn(folderDataTN, "FOLDER_ID") {
+		t.Errorf("Failed to get column: FOLDER_ID")
+	}
+
+	if !db.Migrator().HasColumn(folderDataTN, "FOLDER_NM") {
+		t.Errorf("Failed to get column: FOLDER_NM")
+	}
+
+	folderPropertyTN := "FOLDER_PROPERTY"
+	if !db.Migrator().HasTable(folderPropertyTN) {
+		t.Errorf("Failed to get table: %s", folderPropertyTN)
+	}
+
+	if !db.Migrator().HasColumn(folderPropertyTN, "SEQ") {
+		t.Errorf("Failed to get column: SEQ")
+	}
+
+	if !db.Migrator().HasColumn(folderPropertyTN, "FOLDER_ID") {
+		t.Errorf("Failed to get column: FOLDER_ID")
+	}
+
+	if !db.Migrator().HasColumn(folderPropertyTN, "KEY") {
+		t.Errorf("Failed to get column: KEY")
+	}
+
+	if !db.Migrator().HasColumn(folderPropertyTN, "VALUE") {
+		t.Errorf("Failed to get column: VALUE")
+	}
 }
 
 func TestSkipQuoteIdentifiers(t *testing.T) {
@@ -63,41 +126,95 @@ func TestSkipQuoteIdentifiers(t *testing.T) {
 		t.Fatalf("failed to connect database, got error %v", err)
 	}
 
-	db.Migrator().DropTable(&Student{})
-	db.Migrator().CreateTable(&Student{})
+	db.Migrator().DropTable(&FolderData{}, &FolderProperty{})
+	db.Migrator().CreateTable(&FolderData{}, &FolderProperty{})
 
-	if !db.Migrator().HasTable(&Student{}) {
-		t.Errorf("Failed to get table: student")
+	id := uuid.New().String()
+	folder := FolderData{
+		ID:   id,
+		Name: "My Folder",
+		Properties: []FolderProperty{
+			{
+				ID:    id,
+				Key:   "foo1",
+				Value: "bar1",
+			},
+			{
+				ID:    id,
+				Key:   "foo2",
+				Value: "bar2",
+			},
+		},
 	}
 
-	if !db.Migrator().HasColumn(&Student{}, "ID") {
-		t.Errorf("Failed to get column: id")
+	if err := db.Create(&folder).Error; err != nil {
+		t.Errorf("Failed to insert data, got %v", err)
 	}
 
-	if !db.Migrator().HasColumn(&Student{}, "NAME") {
-		t.Errorf("Failed to get column: name")
+	createdFolder := FolderData{}
+	if err := db.Model(&FolderData{}).Preload("Properties").First(&createdFolder).Error; err != nil {
+		t.Errorf("Failed to query data, got %v", err)
 	}
 
-	student := Student{ID: 1, Name: "John"}
-	if err := db.Model(&Student{}).Create(&student).Error; err != nil {
-		t.Errorf("Failed to insert student, got %v", err)
+	CheckFolderData(t, createdFolder, folder)
+
+	createdFolder.Properties[1].Value = "baz1"
+	createdFolder.Properties = append(createdFolder.Properties, FolderProperty{
+		ID:    id,
+		Key:   "foo3",
+		Value: "bar3",
+	})
+	createdFolder.Properties = append(createdFolder.Properties, FolderProperty{
+		ID:    id,
+		Key:   "foo4",
+		Value: "bar4",
+	})
+	db.Save(&createdFolder)
+
+	updatedFolder := FolderData{}
+	if err := db.Model(&FolderData{}).Preload("Properties").First(&updatedFolder).Error; err != nil {
+		t.Errorf("Failed to query data, got %v", err)
 	}
 
-	var result Student
-	if err := db.First(&result).Error; err != nil {
-		t.Errorf("Failed to query first student, got %v", err)
+	CheckFolderData(t, updatedFolder, createdFolder)
+
+	if err := db.Select(clause.Associations).Delete(&createdFolder).Error; err != nil {
+		t.Errorf("Failed to delete data, got %v", err)
 	}
 
-	if result.ID != student.ID {
-		t.Errorf("id should be %v, but got %v", student.ID, result.ID)
-	}
-
-	if result.Name != student.Name {
-		t.Errorf("name should be %v, but got %v", student.Name, result.Name)
+	result := FolderData{}
+	if err := db.Where("folder_id = ?", createdFolder.ID).First(&result).Error; err == nil || !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("should returns record not found error, but got %v", err)
 	}
 }
 
+func CheckFolderData(t *testing.T, folderData FolderData, expect FolderData) {
+	tests.AssertObjEqual(t, folderData, expect, "ID", "Name")
+	t.Run("Properties", func(t *testing.T) {
+		if len(folderData.Properties) != len(expect.Properties) {
+			t.Fatalf("properties should equal, expect: %v, got %v", len(expect.Properties), len(folderData.Properties))
+		}
+
+		sort.Slice(folderData.Properties, func(i, j int) bool {
+			return folderData.Properties[i].ID > folderData.Properties[j].ID
+		})
+
+		sort.Slice(expect.Properties, func(i, j int) bool {
+			return expect.Properties[i].ID > expect.Properties[j].ID
+		})
+
+		for idx, property := range folderData.Properties {
+			tests.AssertObjEqual(t, property, expect.Properties[idx], "Seq", "ID", "Key", "Value")
+		}
+	})
+}
+
 func TestSkipQuoteIdentifiersSQL(t *testing.T) {
+	type Student struct {
+		ID   uint
+		Name string
+	}
+
 	db, err := openTestDBWithOptions(
 		&oracle.Config{SkipQuoteIdentifiers: true},
 		&gorm.Config{Logger: newLogger})
@@ -109,7 +226,7 @@ func TestSkipQuoteIdentifiersSQL(t *testing.T) {
 	insertedStudent := Student{ID: 1, Name: "John"}
 	result := dryrunDB.Model(&Student{}).Create(&insertedStudent)
 
-	if !regexp.MustCompile(`^INSERT INTO STUDENTS \(name,id\) VALUES \(:1,:2\)$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^INSERT INTO students \(name,id\) VALUES \(:1,:2\)$`).MatchString(result.Statement.SQL.String()) {
 		t.Errorf("invalid insert SQL, got %v", result.Statement.SQL.String())
 	}
 
@@ -117,26 +234,26 @@ func TestSkipQuoteIdentifiersSQL(t *testing.T) {
 	var firstStudent Student
 	result = dryrunDB.First(&firstStudent)
 
-	if !regexp.MustCompile(`^SELECT \* FROM STUDENTS ORDER BY STUDENTS\.id FETCH NEXT 1 ROW ONLY$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^SELECT \* FROM students ORDER BY students\.id FETCH NEXT 1 ROW ONLY$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 
 	// Test Find
 	var foundStudent Student
 	result = dryrunDB.Find(foundStudent, "id = ?", insertedStudent.ID)
-	if !regexp.MustCompile(`^SELECT \* FROM STUDENTS WHERE id = :1$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^SELECT \* FROM students WHERE id = :1$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 
 	// Test Save
 	result = dryrunDB.Save(&Student{ID: 2, Name: "Mary"})
-	if !regexp.MustCompile(`^UPDATE STUDENTS SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^UPDATE students SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 
 	// Update with conditions
 	result = dryrunDB.Model(&Student{}).Where("id = ?", 1).Update("name", "hello")
-	if !regexp.MustCompile(`^UPDATE STUDENTS SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^UPDATE students SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 }

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -39,83 +39,20 @@
 package tests
 
 import (
-	"errors"
 	"regexp"
-	"sort"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/oracle-samples/gorm-oracle/oracle"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
-	"gorm.io/gorm/utils/tests"
 )
 
-type FolderData struct {
-	ID         string           `gorm:"primaryKey;column:folder_id"`
-	Name       string           `gorm:"column:folder_nm"`
-	Properties []FolderProperty `gorm:"foreignKey:ID;PRELOAD:false"`
+type Student struct {
+	ID   uint
+	Name string
 }
 
-func (FolderData) TableName() string {
-	return "folder_data"
-}
-
-type FolderProperty struct {
-	Seq   uint64 `gorm:"autoIncrement"`
-	ID    string `gorm:"primaryKey;column:folder_id"`
-	Key   string `gorm:"primaryKey;unique"`
-	Value string
-}
-
-func (FolderProperty) TableName() string {
-	return "folder_property"
-}
-
-func TestSkipQuoteIdentifiersMigrator(t *testing.T) {
-	db, err := openTestDBWithOptions(
-		&oracle.Config{SkipQuoteIdentifiers: true},
-		&gorm.Config{Logger: newLogger})
-	if err != nil {
-		t.Fatalf("failed to connect database, got error %v", err)
-	}
-
-	db.Migrator().DropTable(&FolderData{}, &FolderProperty{})
-	db.Migrator().CreateTable(&FolderData{}, &FolderProperty{})
-
-	folderDataTN := "FOLDER_DATA"
-	if !db.Migrator().HasTable(folderDataTN) {
-		t.Errorf("Failed to get table: %s", folderDataTN)
-	}
-
-	if !db.Migrator().HasColumn(folderDataTN, "FOLDER_ID") {
-		t.Errorf("Failed to get column: FOLDER_ID")
-	}
-
-	if !db.Migrator().HasColumn(folderDataTN, "FOLDER_NM") {
-		t.Errorf("Failed to get column: FOLDER_NM")
-	}
-
-	folderPropertyTN := "FOLDER_PROPERTY"
-	if !db.Migrator().HasTable(folderPropertyTN) {
-		t.Errorf("Failed to get table: %s", folderPropertyTN)
-	}
-
-	if !db.Migrator().HasColumn(folderPropertyTN, "SEQ") {
-		t.Errorf("Failed to get column: SEQ")
-	}
-
-	if !db.Migrator().HasColumn(folderPropertyTN, "FOLDER_ID") {
-		t.Errorf("Failed to get column: FOLDER_ID")
-	}
-
-	if !db.Migrator().HasColumn(folderPropertyTN, "KEY") {
-		t.Errorf("Failed to get column: KEY")
-	}
-
-	if !db.Migrator().HasColumn(folderPropertyTN, "VALUE") {
-		t.Errorf("Failed to get column: VALUE")
-	}
+func (s Student) TableName() string {
+	return "STUDENTS"
 }
 
 func TestSkipQuoteIdentifiers(t *testing.T) {
@@ -126,95 +63,41 @@ func TestSkipQuoteIdentifiers(t *testing.T) {
 		t.Fatalf("failed to connect database, got error %v", err)
 	}
 
-	db.Migrator().DropTable(&FolderData{}, &FolderProperty{})
-	db.Migrator().CreateTable(&FolderData{}, &FolderProperty{})
+	db.Migrator().DropTable(&Student{})
+	db.Migrator().CreateTable(&Student{})
 
-	id := uuid.New().String()
-	folder := FolderData{
-		ID:   id,
-		Name: "My Folder",
-		Properties: []FolderProperty{
-			{
-				ID:    id,
-				Key:   "foo1",
-				Value: "bar1",
-			},
-			{
-				ID:    id,
-				Key:   "foo2",
-				Value: "bar2",
-			},
-		},
+	if !db.Migrator().HasTable(&Student{}) {
+		t.Errorf("Failed to get table: student")
 	}
 
-	if err := db.Create(&folder).Error; err != nil {
-		t.Errorf("Failed to insert data, got %v", err)
+	if !db.Migrator().HasColumn(&Student{}, "ID") {
+		t.Errorf("Failed to get column: id")
 	}
 
-	createdFolder := FolderData{}
-	if err := db.Model(&FolderData{}).Preload("Properties").First(&createdFolder).Error; err != nil {
-		t.Errorf("Failed to query data, got %v", err)
+	if !db.Migrator().HasColumn(&Student{}, "NAME") {
+		t.Errorf("Failed to get column: name")
 	}
 
-	CheckFolderData(t, createdFolder, folder)
-
-	createdFolder.Properties[1].Value = "baz1"
-	createdFolder.Properties = append(createdFolder.Properties, FolderProperty{
-		ID:    id,
-		Key:   "foo3",
-		Value: "bar3",
-	})
-	createdFolder.Properties = append(createdFolder.Properties, FolderProperty{
-		ID:    id,
-		Key:   "foo4",
-		Value: "bar4",
-	})
-	db.Save(&createdFolder)
-
-	updatedFolder := FolderData{}
-	if err := db.Model(&FolderData{}).Preload("Properties").First(&updatedFolder).Error; err != nil {
-		t.Errorf("Failed to query data, got %v", err)
+	student := Student{ID: 1, Name: "John"}
+	if err := db.Model(&Student{}).Create(&student).Error; err != nil {
+		t.Errorf("Failed to insert student, got %v", err)
 	}
 
-	CheckFolderData(t, updatedFolder, createdFolder)
-
-	if err := db.Select(clause.Associations).Delete(&createdFolder).Error; err != nil {
-		t.Errorf("Failed to delete data, got %v", err)
+	var result Student
+	if err := db.First(&result).Error; err != nil {
+		t.Errorf("Failed to query first student, got %v", err)
 	}
 
-	result := FolderData{}
-	if err := db.Where("folder_id = ?", createdFolder.ID).First(&result).Error; err == nil || !errors.Is(err, gorm.ErrRecordNotFound) {
-		t.Errorf("should returns record not found error, but got %v", err)
+	if result.ID != student.ID {
+		t.Errorf("id should be %v, but got %v", student.ID, result.ID)
 	}
-}
 
-func CheckFolderData(t *testing.T, folderData FolderData, expect FolderData) {
-	tests.AssertObjEqual(t, folderData, expect, "ID", "Name")
-	t.Run("Properties", func(t *testing.T) {
-		if len(folderData.Properties) != len(expect.Properties) {
-			t.Fatalf("properties should equal, expect: %v, got %v", len(expect.Properties), len(folderData.Properties))
-		}
-
-		sort.Slice(folderData.Properties, func(i, j int) bool {
-			return folderData.Properties[i].ID > folderData.Properties[j].ID
-		})
-
-		sort.Slice(expect.Properties, func(i, j int) bool {
-			return expect.Properties[i].ID > expect.Properties[j].ID
-		})
-
-		for idx, property := range folderData.Properties {
-			tests.AssertObjEqual(t, property, expect.Properties[idx], "Seq", "ID", "Key", "Value")
-		}
-	})
+	if result.Name != student.Name {
+		t.Errorf("name should be %v, but got %v", student.Name, result.Name)
+	}
 }
 
 func TestSkipQuoteIdentifiersSQL(t *testing.T) {
-	type Student struct {
-		ID   uint
-		Name string
-	}
-
 	db, err := openTestDBWithOptions(
 		&oracle.Config{SkipQuoteIdentifiers: true},
 		&gorm.Config{Logger: newLogger})
@@ -226,7 +109,7 @@ func TestSkipQuoteIdentifiersSQL(t *testing.T) {
 	insertedStudent := Student{ID: 1, Name: "John"}
 	result := dryrunDB.Model(&Student{}).Create(&insertedStudent)
 
-	if !regexp.MustCompile(`^INSERT INTO students \(name,id\) VALUES \(:1,:2\)$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^INSERT INTO STUDENTS \(name,id\) VALUES \(:1,:2\)$`).MatchString(result.Statement.SQL.String()) {
 		t.Errorf("invalid insert SQL, got %v", result.Statement.SQL.String())
 	}
 
@@ -234,26 +117,26 @@ func TestSkipQuoteIdentifiersSQL(t *testing.T) {
 	var firstStudent Student
 	result = dryrunDB.First(&firstStudent)
 
-	if !regexp.MustCompile(`^SELECT \* FROM students ORDER BY students\.id FETCH NEXT 1 ROW ONLY$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^SELECT \* FROM STUDENTS ORDER BY STUDENTS\.id FETCH NEXT 1 ROW ONLY$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 
 	// Test Find
 	var foundStudent Student
 	result = dryrunDB.Find(foundStudent, "id = ?", insertedStudent.ID)
-	if !regexp.MustCompile(`^SELECT \* FROM students WHERE id = :1$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^SELECT \* FROM STUDENTS WHERE id = :1$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 
 	// Test Save
 	result = dryrunDB.Save(&Student{ID: 2, Name: "Mary"})
-	if !regexp.MustCompile(`^UPDATE students SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^UPDATE STUDENTS SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 
 	// Update with conditions
 	result = dryrunDB.Model(&Student{}).Where("id = ?", 1).Update("name", "hello")
-	if !regexp.MustCompile(`^UPDATE students SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
+	if !regexp.MustCompile(`^UPDATE STUDENTS SET name=:1 WHERE id = :2$`).MatchString(result.Statement.SQL.String()) {
 		t.Fatalf("SQL should include selected names, but got %v", result.Statement.SQL.String())
 	}
 }

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -357,3 +357,24 @@ func db(unscoped bool) *gorm.DB {
 		return DB
 	}
 }
+
+func CheckFolderData(t *testing.T, folderData FolderData, expect FolderData) {
+	tests.AssertObjEqual(t, folderData, expect, "ID", "Name")
+	t.Run("Properties", func(t *testing.T) {
+		if len(folderData.Properties) != len(expect.Properties) {
+			t.Fatalf("properties should equal, expect: %v, got %v", len(expect.Properties), len(folderData.Properties))
+		}
+
+		sort.Slice(folderData.Properties, func(i, j int) bool {
+			return folderData.Properties[i].ID > folderData.Properties[j].ID
+		})
+
+		sort.Slice(expect.Properties, func(i, j int) bool {
+			return expect.Properties[i].ID > expect.Properties[j].ID
+		})
+
+		for idx, property := range folderData.Properties {
+			tests.AssertObjEqual(t, property, expect.Properties[idx], "Seq", "ID", "Key", "Value")
+		}
+	})
+}

--- a/tests/utils/models.go
+++ b/tests/utils/models.go
@@ -102,3 +102,16 @@ type Child struct {
 	ParentID *uint
 	Parent   *Parent
 }
+
+type FolderProperty struct {
+	Seq   uint64 `gorm:"autoIncrement"`
+	ID    string `gorm:"primaryKey;column:folder_id"`
+	Key   string `gorm:"primaryKey;unique"`
+	Value string
+}
+
+type FolderData struct {
+	ID         string           `gorm:"primaryKey;column:folder_id"`
+	Name       string           `gorm:"column:folder_nm"`
+	Properties []FolderProperty `gorm:"foreignKey:ID;PRELOAD:false"`
+}


### PR DESCRIPTION
This PR incorporate the changes from [FixPLSQLAutoIncrement](https://github.com/oracle-samples/gorm-oracle/compare/main...joboon:gorm-oracle:FixPLSQLAutoIncrement).

### Issue 1

The PR fixes the issue of the previous commit which add supports of skipping quoting identifiers. The solution uses writeQuotedIdentifier directly, which fails when trying to avoid quoting the identifiers. Instead, it should go through  db.QuoteTo so that the configuration option can decide whether to actually quote anything.

### Issue 2

When updating a struct with a one-to-many relationship, the update attempts to insert NULL into the auto-increment field of the new row. The fix is simply to exclude auto-increment fields when generating the SQL.

This change also adds the test `TestSaveAssociationWithAutoIncrementField` to verify the fix.