### PR TITLE
Resolve missing COLUMN keyword when dropping a column

### DIFF
--- a/oracle/migrator.go
+++ b/oracle/migrator.go
@@ -310,7 +310,7 @@ func (m Migrator) DropColumn(value interface{}, name string) error {
 		}
 
 		return m.DB.Exec(
-			"ALTER TABLE ? DROP ?",
+			"ALTER TABLE ? DROP COLUMN ?",
 			clause.Table{Name: stmt.Schema.Table},
 			clause.Column{Name: name},
 		).Error


### PR DESCRIPTION
This PR resolves Issue #80 by ensuring that the generated SQL statement for dropping columns includes the required COLUMN keyword.