### PR TITLE
fix: use TABLE OF CLOB for large string updates

### DIFF
--- a/oracle/create.go
+++ b/oracle/create.go
@@ -300,6 +300,17 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 		} else {
 			arrayType = "TABLE OF VARCHAR2(4000)"
 		}
+		for i, ccolumn := range createValues.Columns {
+			if strings.EqualFold(ccolumn.Name, column.Name) {
+				for j := range createValues.Values {
+					if strValue, ok := createValues.Values[j][i].(string); ok {
+						if len(strValue) > 4000 {
+							arrayType = "TABLE OF CLOB"
+						}
+					}
+				}
+			}
+		}
 
 		plsqlBuilder.WriteString(fmt.Sprintf("  TYPE t_col_%d_array IS %s;\n", i, arrayType))
 		plsqlBuilder.WriteString(fmt.Sprintf("  l_col_%d_array t_col_%d_array;\n", i, i))
@@ -582,6 +593,17 @@ func buildBulkInsertOnlyPLSQL(db *gorm.DB, createValues clause.Values) {
 			arrayType = getOracleArrayType(field)
 		} else {
 			arrayType = "TABLE OF VARCHAR2(4000)"
+		}
+		for i, ccolumn := range createValues.Columns {
+			if strings.EqualFold(ccolumn.Name, column.Name) {
+				for j := range createValues.Values {
+					if strValue, ok := createValues.Values[j][i].(string); ok {
+						if len(strValue) > 4000 {
+							arrayType = "TABLE OF CLOB"
+						}
+					}
+				}
+			}
 		}
 
 		plsqlBuilder.WriteString(fmt.Sprintf("  TYPE t_col_%d_array IS %s;\n", i, arrayType))


### PR DESCRIPTION
# Description

Tests the length of an updated string and if it is in excess of 4000 characters, converts the update table to be `TABLE OF CLOB`. Without this change, you get a `ORA-06502: PL/SQL: value or conversion error: character string buffer too small` error when the updated text overruns the 4000 string VARCHAR2 limit.

**NOTE:** This fix is rudimentary and this PR is just a draft PR to test if the OCA has been signed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Used this test program:
```
package main

import (
	"fmt"

	"github.com/google/uuid"
	"github.com/oracle-samples/gorm-oracle/oracle"
	"gorm.io/gorm"
)

type FolderData struct {
	ID         string           `gorm:"primaryKey;column:folder_id"`
	Name       string           `gorm:"column:folder_nm"`
	Properties []FolderProperty `gorm:"foreignKey:ID;PRELOAD:false"`
}

func (FolderData) TableName() string {
	return "folder_data"
}

type FolderProperty struct {
	Blah  uint64 `gorm:"column:blah;autoIncrement"`
	ID    string `gorm:"primaryKey;column:folder_id"`
	Key   string `gorm:"primaryKey;unique;column:key"`
	Value string `gorm:"column:value"`
}

func (FolderProperty) TableName() string {
	return "folder_property"
}

func initialize(db *gorm.DB) {
	_ = db.Exec("DROP TABLE folder_property CASCADE CONSTRAINTS")
	_ = db.Exec("DROP TABLE folder_data CASCADE CONSTRAINTS")

	db.Exec(`
		CREATE TABLE folder_data (
			folder_id VARCHAR2(36) NOT NULL,
			folder_nm VARCHAR2(100 CHAR) NOT NULL,
			CONSTRAINT folder_data_pk PRIMARY KEY (folder_id))
	`)
	err := db.Error
	if err != nil {
		panic(err)
	}

	db.Exec(`
		CREATE TABLE folder_property (
			blah NUMBER GENERATED BY DEFAULT AS IDENTITY (START WITH 1),
			folder_id VARCHAR2(36) NOT NULL,
			value CLOB,
			key VARCHAR2(100) NOT NULL UNIQUE,
			CONSTRAINT folder_property_pk PRIMARY KEY (folder_id, key),
			CONSTRAINT folder_property_fk01 FOREIGN KEY (folder_id) REFERENCES folder_data (folder_id)
		)
	`)
	err = db.Error
	if err != nil {
		panic(err)
	}

	db.Debug()
}

func main() {
	dsn := <REDACTED>

	db, err := gorm.Open(oracle.Dialector{
		Config: &oracle.Config{
			DataSourceName:       dsn,
			SkipQuoteIdentifiers: true,
		},
	}, &gorm.Config{})
	if err != nil {
		panic(err)
	}

	initialize(db)

	id := uuid.New().String()
	folder := &FolderData{
		ID:   id,
		Name: "My Folder",
		Properties: []FolderProperty{
			{
				ID:    id,
				Key:   "prop1",
				Value: "some string value",
			},
			{
				ID:    id,
				Key:   "prop2",
				Value: "some other string value",
			},
		},
	}
	err = db.Transaction(func(tx *gorm.DB) error {
		if err := tx.Create(&folder).Error; err != nil {
			tx.Rollback()
			return err
		}
		return nil
	})
	if err != nil {
		panic(err)
	}

	createdFolder := &FolderData{}
	db.Model(&FolderData{}).Preload("Properties").First(&createdFolder)
	fmt.Printf("Done! Created record: %v\n", createdFolder)

	clobContent := `
<TRUNCATED>
	`
	createdFolder.Properties[1].Value = clobContent
	db.Save(&createdFolder)
	fmt.Printf("Done! Updated record: %v\n", createdFolder)
}
```