### PR TITLE
Fix issue 81

### DIFF
--- a/tests/sql_builder_test.go
+++ b/tests/sql_builder_test.go
@@ -859,13 +859,12 @@ func TestToSQL(t *testing.T) {
 	})
 	assertEqualSQL(t, `UPDATE "custom_update_table" SET "updated_at"=?,"name"='patched',"age"=99 WHERE id = 200`, sql)
 
-	// https://github.com/oracle-samples/gorm-oracle/issues/81
-	// sql = DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
-	// 	return tx.Clauses(clause.Update{Table: clause.Table{Name: "custom_update_table"}}).
-	// 		Where("id = ?", 200).
-	// 		Updates(&User{Name: "patched", Age: 99})
-	// })
-	// assertEqualSQL(t, `UPDATE "custom_update_table" SET "updated_at"=?,"name"='patched',"age"=99 WHERE id = 200 AND "custom_update_table"."deleted_at" IS NULL`, sql)
+	sql = DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
+		return tx.Clauses(clause.Update{Table: clause.Table{Name: "custom_update_table"}}).
+			Where("id = ?", 200).
+			Updates(&User{Name: "patched", Age: 99})
+	})
+	assertEqualSQL(t, `UPDATE "custom_update_table" SET "updated_at"=?,"name"='patched',"age"=99 WHERE id = 200 AND "custom_update_table"."deleted_at" IS NULL`, sql)
 
 	// update
 	sql = DB.ToSQL(func(tx *gorm.DB) *gorm.DB {

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -1163,15 +1163,3 @@ func TestUpdateCustomDataType(t *testing.T) {
 		t.Errorf("failed to update custom data type field: %v", err)
 	}
 }
-
-func TestUpdateWithCustomTableName(t *testing.T) {
-	sql := DB.ToSQL(func(tx *gorm.DB) *gorm.DB {
-		return tx.Clauses(clause.Update{
-			Table: clause.Table{Name: "custom_update_table"},
-		}).Where("id = ?", 200).
-			Updates(&User{Name: "patched", Age: 99})
-	})
-
-	assertEqualSQL(t, `UPDATE "custom_update_table" SET "updated_at"=?,"name"='patched',"age"=99 WHERE id = 200 AND "custom_update_table"."deleted_at" IS NULL`, sql)
-
-}


### PR DESCRIPTION
### Description 
Fixes incorrect soft-delete table reference when performing updates with a custom table name (via clause.Update{Table: ...}). Fixes #81
### Result
 -- generated SQL : UPDATE "custom_update_table" SET "updated_at"='2025-10-08 23:16:47.41',"name"='patched',"age"=99 WHERE id = 200 AND "custom_update_table"."deleted_at" IS NULL 
 
