### PR TITLE
Add a space before table_options

### DIFF
--- a/oracle/migrator.go
+++ b/oracle/migrator.go
@@ -202,7 +202,7 @@ func (m Migrator) CreateTable(values ...interface{}) error {
 			createTableSQL += ")"
 
 			if tableOption, ok := m.DB.Get("gorm:table_options"); ok {
-				createTableSQL += fmt.Sprint(tableOption)
+				createTableSQL += " " + fmt.Sprint(tableOption)
 			}
 
 			err = tx.Exec(createTableSQL, values...).Error


### PR DESCRIPTION
# Description

Fix Migrator implementation by adding the missing space before table options in the generated SQL.

Fixes # 68

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)