### PR TITLE
resolve the Issue #100 columnname is the constraint not quoted

### DIFF
--- a/tests/json_bulk_2_test.go
+++ b/tests/json_bulk_2_test.go
@@ -405,7 +405,6 @@ func TestUnicodeJSON(t *testing.T) {
 }
 
 func TestJSONStrict(t *testing.T) {
-	t.Skip("Skipping due to issue #100")
 	type StrictJSONRecord struct {
 		ID      uint           `gorm:"primaryKey;autoIncrement;column:record_id"`
 		DocJson datatypes.JSON `gorm:"type:CLOB;column:doc;check:doc_is_json_strict,doc IS JSON (STRICT)"`
@@ -422,7 +421,6 @@ func TestJSONStrict(t *testing.T) {
 }
 
 func TestJSONLAX(t *testing.T) {
-	t.Skip("Skipping due to issue #100")
 	type LaxJSONRecord struct {
 		ID  uint           `gorm:"primaryKey;autoIncrement;column:record_id"`
 		Doc datatypes.JSON `gorm:"type:CLOB;column:doc;check:doc_is_json_lax,doc IS JSON(LAX)"`


### PR DESCRIPTION
# Description

This PR fixes an issue where column names in table-level CHECK constraints were not properly quoted when generating CREATE TABLE statements for Oracle databases.

Fixes #100 

## Changes 

we look at each field (column) in the schema.

If the column name appears in the constraint, it uses a regex with word boundaries (\b) to replace only whole words, avoiding partial matches (like "doc" inside "document").

and we use the `QuoteIdentifier(f.DBName)` to quotes the column name.

This ensures the final SQL looks like:
`CONSTRAINT "doc_is_json_lax" CHECK ("doc" IS JSON(LAX))`
