### PR TITLE
fix: PLSQL batch LOB handling

### DIFF
--- a/oracle/common.go
+++ b/oracle/common.go
@@ -41,9 +41,8 @@ package oracle
 import (
 	"bytes"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
-	"fmt"
-	"math"
 	"reflect"
 	"strings"
 	"time"
@@ -52,50 +51,50 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 )
 
 // Extra data types for the data type that are not declared in the
 // default DataType list
 const (
-	JSON                  schema.DataType = "json"
 	Timestamp             schema.DataType = "timestamp"
 	TimestampWithTimeZone schema.DataType = "timestamp with time zone"
 )
 
 // Helper function to get Oracle array type for a field
-func getOracleArrayType(field *schema.Field, values []any) string {
-	switch field.DataType {
-	case schema.Bool:
-		return "TABLE OF NUMBER(1)"
-	case schema.Int, schema.Uint:
-		return "TABLE OF NUMBER"
-	case schema.Float:
-		return "TABLE OF NUMBER"
-	case JSON:
-		// PL/SQL does not yet allow declaring collections of JSON (TABLE OF JSON) directly.
-		// Workaround for JSON type
-		fallthrough
-	case schema.String:
-		if field.Size > 0 && field.Size <= 4000 {
-			return fmt.Sprintf("TABLE OF VARCHAR2(%d)", field.Size)
-		} else {
-			for _, value := range values {
-				if strValue, ok := value.(string); ok {
-					if len(strValue) > 4000 {
-						return "TABLE OF CLOB"
-					}
-				}
+func getOracleArrayType(values []any) string {
+	arrayType := "TABLE OF VARCHAR2(4000)"
+	for _, val := range values {
+		if val == nil {
+			continue
+		}
+		switch v := val.(type) {
+		case bool:
+			arrayType = "TABLE OF NUMBER(1)"
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+			arrayType = "TABLE OF NUMBER"
+		case time.Time:
+			arrayType = "TABLE OF TIMESTAMP WITH TIME ZONE"
+		case godror.Lob:
+			if v.IsClob {
+				return "TABLE OF CLOB"
+			} else {
+				return "TABLE OF BLOB"
+			}
+		case []byte:
+			// Store byte slices longer than 4000 bytes as BLOB
+			if len(v) > 4000 {
+				return "TABLE OF BLOB"
+			}
+		case string:
+			// Store strings longer than 4000 characters as CLOB
+			if len(v) > 4000 {
+				return "TABLE OF CLOB"
 			}
 		}
-		return "TABLE OF VARCHAR2(4000)"
-	case schema.Time:
-		return "TABLE OF TIMESTAMP WITH TIME ZONE"
-	case schema.Bytes:
-		return "TABLE OF BLOB"
-	default:
-		return "TABLE OF " + strings.ToUpper(string(field.DataType))
 	}
+	return arrayType
 }
 
 // Helper function to get all column names for a table
@@ -129,6 +128,12 @@ func findFieldByDBName(schema *schema.Schema, dbName string) *schema.Field {
 func createTypedDestination(f *schema.Field) interface{} {
 	if f == nil {
 		return new(string)
+	}
+
+	// To differentiate between bool fields stored as NUMBER(1) and bool fields stored as actual BOOLEAN type,
+	// check the struct's "type" tag.
+	if f.DataType == "boolean" {
+		return new(bool)
 	}
 
 	// If the field has a serializer, the field type may not be directly related to the column type in the database.
@@ -204,13 +209,17 @@ func createTypedDestination(f *schema.Field) interface{} {
 
 	case reflect.Float32, reflect.Float64:
 		return new(float64)
+
+	case reflect.Slice:
+		if ft.Elem().Kind() == reflect.Uint8 { // []byte
+			return new([]byte)
+		}
 	}
 
 	// Fallback
 	return new(string)
 }
 
-// Convert values for Oracle-specific types
 func convertValue(val interface{}) interface{} {
 	if val == nil {
 		return nil
@@ -221,6 +230,10 @@ func convertValue(val interface{}) interface{} {
 	for rv.Kind() == reflect.Ptr && !rv.IsNil() {
 		rv = rv.Elem()
 		val = rv.Interface()
+	}
+	isNil := false
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		isNil = true
 	}
 
 	switch v := val.(type) {
@@ -238,7 +251,7 @@ func convertValue(val interface{}) interface{} {
 	case *uuid.UUID, *datatypes.UUID:
 		// Convert nil pointer to a UUID to empty string so that it is stored in the database as NULL
 		// rather than "00000000-0000-0000-0000-000000000000"
-		if rv.IsNil() {
+		if isNil {
 			return ""
 		}
 		return val
@@ -249,15 +262,31 @@ func convertValue(val interface{}) interface{} {
 			return 0
 		}
 	case string:
-		if len(v) > math.MaxInt16 {
+		// Store strings longer than 4000 characters as CLOB
+		if len(v) > 4000 {
 			return godror.Lob{IsClob: true, Reader: strings.NewReader(v)}
 		}
 		return v
 	case []byte:
-		if len(v) > math.MaxInt16 {
+		// Store byte slices longer than 4000 bytes as BLOB
+		if len(v) > 4000 {
 			return godror.Lob{IsClob: false, Reader: bytes.NewReader(v)}
 		}
 		return v
+	case driver.Valuer:
+		// Unwrap driver.Valuer to its underlying type by recursing into
+		// convertValue until we get a non-Valuer type
+		if v == nil || isNil {
+			return val
+		}
+		unwrappedValue, err := v.Value()
+		if err != nil {
+			return val
+		}
+		return convertValue(unwrappedValue)
+	case clause.Expr:
+		// If we get a clause.Expr, convert it to nil; it should be handled elsewhere
+		return nil
 	default:
 		return val
 	}
@@ -283,6 +312,13 @@ func convertFromOracleToField(value interface{}, field *schema.Field) interface{
 	isPtr := field.FieldType.Kind() == reflect.Ptr
 	if isPtr {
 		targetType = field.FieldType.Elem()
+	}
+
+	// When PL/SQL LOBs are returned, skip conversion.
+	// LOB addresses are freed by the driver after the query, so we cannot read their content
+	// from the return value. If you need to read stored LOB content, do it in a separate query.
+	if _, ok := value.(godror.Lob); ok {
+		return nil
 	}
 
 	switch targetType {
@@ -318,6 +354,16 @@ func convertFromOracleToField(value interface{}, field *schema.Field) interface{
 		default:
 			converted = value
 		}
+	case reflect.TypeOf(uuid.UUID{}), reflect.TypeOf(datatypes.UUID{}):
+		uuidStr, ok := value.(string)
+		if !ok {
+			return nil
+		}
+		parsed, err := uuid.Parse(uuidStr)
+		if err != nil {
+			return nil
+		}
+		converted = parsed
 
 	case reflect.TypeOf(time.Time{}):
 		switch vv := value.(type) {
@@ -388,6 +434,12 @@ func convertFromOracleToField(value interface{}, field *schema.Field) interface{
 }
 
 func isJSONField(f *schema.Field) bool {
+	// Support detecting JSON fields through the struct's "type" tag.
+	// Also support jsonb for compatibility with other databases.
+	if f.DataType == "json" || f.DataType == "jsonb" {
+		return true
+	}
+
 	_rawMsgT := reflect.TypeOf(json.RawMessage{})
 	_gormJSON := reflect.TypeOf(datatypes.JSON{})
 	if f == nil {

--- a/tests/blob_test.go
+++ b/tests/blob_test.go
@@ -41,7 +41,6 @@ package tests
 import (
 	"bytes"
 	"crypto/rand"
-	"strings"
 	"testing"
 	"time"
 
@@ -63,22 +62,12 @@ type BlobVariantModel struct {
 	LargeBlob []byte `gorm:"type:blob"`
 }
 
-type BlobOneToManyModel struct {
-	ID       uint             `gorm:"primaryKey"`
-	Children []BlobChildModel `gorm:"foreignKey:ID"`
-}
-
-type BlobChildModel struct {
-	ID   uint   `gorm:"primaryKey"`
-	Data []byte `gorm:"type:blob"`
-}
-
 func setupBlobTestTables(t *testing.T) {
 	t.Log("Setting up BLOB test tables")
 
-	DB.Migrator().DropTable(&BlobTestModel{}, &BlobVariantModel{}, &BlobOneToManyModel{}, &BlobChildModel{})
+	DB.Migrator().DropTable(&BlobTestModel{}, &BlobVariantModel{})
 
-	err := DB.AutoMigrate(&BlobTestModel{}, &BlobVariantModel{}, &BlobOneToManyModel{}, &BlobChildModel{})
+	err := DB.AutoMigrate(&BlobTestModel{}, &BlobVariantModel{})
 	if err != nil {
 		t.Fatalf("Failed to migrate BLOB test tables: %v", err)
 	}
@@ -431,23 +420,6 @@ func TestBlobWithReturning(t *testing.T) {
 
 	if model.CreatedAt.IsZero() {
 		t.Error("Expected CreatedAt timestamp in RETURNING")
-	}
-}
-
-func TestBlobOnConflict(t *testing.T) {
-	setupBlobTestTables(t)
-
-	model := &BlobOneToManyModel{
-		ID: 1,
-		Children: []BlobChildModel{
-			{
-				Data: []byte(strings.Repeat("X", 32768)),
-			},
-		},
-	}
-	err := DB.Create(model).Error
-	if err != nil {
-		t.Fatalf("Failed to create BLOB record with ON CONFLICT: %v", err)
 	}
 }
 

--- a/tests/boolean_test.go
+++ b/tests/boolean_test.go
@@ -40,8 +40,8 @@ package tests
 
 import (
 	"database/sql"
-	"testing"
 	"strings"
+	"testing"
 )
 
 type BooleanTest struct {
@@ -135,23 +135,23 @@ func TestBooleanQueryFilters(t *testing.T) {
 }
 
 func TestBooleanNegativeInvalidDBValue(t *testing.T) {
-    DB.Migrator().DropTable(&BooleanTest{})
-    DB.AutoMigrate(&BooleanTest{})
+	DB.Migrator().DropTable(&BooleanTest{})
+	DB.AutoMigrate(&BooleanTest{})
 
-    if err := DB.Exec(`INSERT INTO "BOOLEAN_TESTS" ("ID","FLAG") VALUES (2001, 2)`).Error; err != nil {
-        t.Fatalf("failed to insert invalid bool: %v", err)
-    }
+	if err := DB.Exec(`INSERT INTO "BOOLEAN_TESTS" ("ID","FLAG") VALUES (2001, 2)`).Error; err != nil {
+		t.Fatalf("failed to insert invalid bool: %v", err)
+	}
 
-    var got BooleanTest
-    err := DB.First(&got, 2001).Error
-    if err == nil {
-        t.Fatal("expected invalid boolean scan error, got nil")
-    }
+	var got BooleanTest
+	err := DB.First(&got, 2001).Error
+	if err == nil {
+		t.Fatal("expected invalid boolean scan error, got nil")
+	}
 
-    if !strings.Contains(err.Error(), "invalid") &&
-       !strings.Contains(err.Error(), "convert") {
-        t.Fatalf("expected boolean conversion error, got: %v", err)
-    }
+	if !strings.Contains(err.Error(), "invalid") &&
+		!strings.Contains(err.Error(), "convert") {
+		t.Fatalf("expected boolean conversion error, got: %v", err)
+	}
 }
 
 func TestBooleanInsertWithIntValues(t *testing.T) {
@@ -213,26 +213,26 @@ func TestBooleanDefaultValue(t *testing.T) {
 }
 
 func TestBooleanQueryMixedComparisons(t *testing.T) {
-    DB.Migrator().DropTable(&BooleanTest{})
-    DB.AutoMigrate(&BooleanTest{})
+	DB.Migrator().DropTable(&BooleanTest{})
+	DB.AutoMigrate(&BooleanTest{})
 
-    DB.Create(&BooleanTest{Flag: true})
-    DB.Create(&BooleanTest{Flag: false})
+	DB.Create(&BooleanTest{Flag: true})
+	DB.Create(&BooleanTest{Flag: false})
 
-    var gotNum []BooleanTest
+	var gotNum []BooleanTest
 
-    // FILTER USING NUMBER
-    if err := DB.Where("FLAG = 1").Find(&gotNum).Error; err != nil {
-        t.Fatal(err)
-    }
-    if len(gotNum) == 0 {
-        t.Errorf("expected at least 1 row for FLAG=1")
-    }
+	// FILTER USING NUMBER
+	if err := DB.Where("FLAG = 1").Find(&gotNum).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(gotNum) == 0 {
+		t.Errorf("expected at least 1 row for FLAG=1")
+	}
 
-    var gotStr []BooleanTest
-    if err := DB.Where("FLAG = 'true'").Find(&gotStr).Error; err == nil {
-        t.Errorf("expected ORA-01722 when comparing NUMBER to string literal")
-    }
+	var gotStr []BooleanTest
+	if err := DB.Where("FLAG = 'true'").Find(&gotStr).Error; err == nil {
+		t.Errorf("expected ORA-01722 when comparing NUMBER to string literal")
+	}
 }
 
 func TestBooleanStringCoercion(t *testing.T) {
@@ -259,7 +259,6 @@ func TestBooleanStringCoercion(t *testing.T) {
 	}
 }
 
-
 func TestBooleanNullableColumn(t *testing.T) {
 	t.Skip("Skipping until nullable bool bug is resolved")
 	DB.Migrator().DropTable(&BooleanTest{})
@@ -278,5 +277,80 @@ func TestBooleanNullableColumn(t *testing.T) {
 
 	if got.Nullable != nil {
 		t.Errorf("expected NULL, got %v", *got.Nullable)
+	}
+}
+
+type Model struct {
+	ID       uint         `gorm:"primaryKey"`
+	Children []ChildModel `gorm:"foreignKey:ParentID"`
+}
+
+type ChildModel struct {
+	ParentID uint
+	ID       uint `gorm:"primaryKey"`
+	Data     bool `gorm:"type:boolean"`
+}
+
+func setupBooleanTestTables(t *testing.T) {
+	t.Log("Setting up boolean test tables")
+
+	DB.Migrator().DropTable(&Model{}, &ChildModel{})
+
+	err := DB.AutoMigrate(&Model{}, &ChildModel{})
+	if err != nil {
+		t.Fatalf("Failed to migrate boolean test tables: %v", err)
+	}
+
+	t.Log("boolean test tables created successfully")
+}
+
+func TestBooleanOnConflict(t *testing.T) {
+	type test struct {
+		model any
+		fn    func(model any) error
+	}
+	tests := map[string]test{
+		"OneToManySingle": {
+			model: &Model{
+				ID: 1,
+				Children: []ChildModel{
+					{
+						ID:   1,
+						Data: true,
+					},
+				},
+			},
+			fn: func(model any) error {
+				return DB.Create(model).Error
+			},
+		},
+		"OneToManyBatch": {
+			model: &Model{
+				ID: 1,
+				Children: []ChildModel{
+					{
+						ID:   1,
+						Data: true,
+					},
+					{
+						ID:   2,
+						Data: false,
+					},
+				},
+			},
+			fn: func(model any) error {
+				return DB.Create(model).Error
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setupBooleanTestTables(t)
+			err := tc.fn(tc.model)
+			if err != nil {
+				t.Fatalf("Failed to create boolean record with ON CONFLICT: %v", err)
+			}
+		})
 	}
 }

--- a/tests/lob_test.go
+++ b/tests/lob_test.go
@@ -1,0 +1,371 @@
+/*
+** Copyright (c) 2025 Oracle and/or its affiliates.
+**
+** The Universal Permissive License (UPL), Version 1.0
+**
+** Subject to the condition set forth below, permission is hereby granted to any
+** person obtaining a copy of this software, associated documentation and/or data
+** (collectively the "Software"), free of charge and under any and all copyright
+** rights in the Software, and any and all patent rights owned or freely
+** licensable by each licensor hereunder covering either (i) the unmodified
+** Software as contributed to or provided by such licensor, or (ii) the Larger
+** Works (as defined below), to deal in both
+**
+** (a) the Software, and
+** (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+** one is included with the Software (each a "Larger Work" to which the Software
+** is contributed by such licensors),
+**
+** without restriction, including without limitation the rights to copy, create
+** derivative works of, display, perform, and distribute the Software and make,
+** use, sell, offer for sale, import, export, have made, and have sold the
+** Software and the Larger Work(s), and to sublicense the foregoing rights on
+** either these or other terms.
+**
+** This license is subject to the following condition:
+** The above copyright notice and either this complete permission notice or at
+** a minimum a reference to the UPL must be included in all copies or
+** substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+** SOFTWARE.
+ */
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/gorm/clause"
+)
+
+type ClobOneToManyModel struct {
+	ID       uint             `gorm:"primaryKey"`
+	Children []ClobChildModel `gorm:"foreignKey:ParentID"`
+}
+
+type ClobChildModel struct {
+	ParentID uint
+	Blah     string `gorm:"primaryKey"`
+	Data     string `gorm:"type:clob"`
+}
+
+type ClobSingleModel struct {
+	Blah string `gorm:"primaryKey"`
+	Data string `gorm:"type:clob"`
+}
+
+type BlobOneToManyModel struct {
+	ID       uint             `gorm:"primaryKey"`
+	Children []BlobChildModel `gorm:"foreignKey:ParentID"`
+}
+
+type BlobChildModel struct {
+	ParentID uint
+	Blah     string `gorm:"primaryKey"`
+	Data     []byte `gorm:"type:blob"`
+}
+
+type BlobSingleModel struct {
+	ID   uint   `gorm:"primaryKey"`
+	Data []byte `gorm:"type:blob"`
+}
+
+func setupLobTestTables(t *testing.T) {
+	t.Log("Setting up LOB test tables")
+
+	DB.Migrator().DropTable(&ClobOneToManyModel{}, &ClobChildModel{}, &ClobSingleModel{}, &BlobOneToManyModel{}, &BlobChildModel{}, &BlobSingleModel{})
+
+	err := DB.AutoMigrate(&ClobOneToManyModel{}, &ClobChildModel{}, &ClobSingleModel{}, &BlobOneToManyModel{}, &BlobChildModel{}, &BlobSingleModel{})
+	if err != nil {
+		t.Fatalf("Failed to migrate LOB test tables: %v", err)
+	}
+
+	t.Log("LOB test tables created successfully")
+}
+
+func TestClobOnConflict(t *testing.T) {
+	type test struct {
+		model any
+		fn    func(model any) error
+	}
+	tests := map[string]test{
+		"OneToManySingle": {
+			model: &ClobOneToManyModel{
+				ID: 1,
+				Children: []ClobChildModel{
+					{
+						Blah: "1",
+						Data: strings.Repeat("X", 32768),
+					},
+				},
+			},
+			fn: func(model any) error {
+				return DB.Create(model).Error
+			},
+		},
+		"OneToManyBatch": {
+			model: &ClobOneToManyModel{
+				ID: 1,
+				Children: []ClobChildModel{
+					{
+						Blah: "1",
+						Data: strings.Repeat("X", 32768),
+					},
+					{
+						Blah: "2",
+						Data: strings.Repeat("Y", 3),
+					},
+				},
+			},
+			fn: func(model any) error {
+				return DB.Create(model).Error
+			},
+		},
+		"Single": {
+			model: []ClobSingleModel{
+				{
+					Blah: "1",
+					Data: strings.Repeat("X", 32768),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleNotQuiteLOB": {
+			model: []ClobSingleModel{
+				{
+					Blah: "1",
+					Data: strings.Repeat("X", 32767),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleBatch": {
+			model: []ClobSingleModel{
+				{
+					Blah: "1",
+					Data: strings.Repeat("X", 32768),
+				},
+				{
+					Blah: "2",
+					Data: strings.Repeat("Y", 3),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleBatchNotQuiteLOB": {
+			model: []ClobSingleModel{
+				{
+					Blah: "1",
+					Data: strings.Repeat("X", 32767),
+				},
+				{
+					Blah: "2",
+					Data: strings.Repeat("Y", 3),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleBatchReverse": {
+			model: []ClobSingleModel{
+				{
+					Blah: "1",
+					Data: strings.Repeat("Y", 3),
+				},
+				{
+					Blah: "2",
+					Data: strings.Repeat("X", 32768),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setupLobTestTables(t)
+			err := tc.fn(tc.model)
+			if err != nil {
+				t.Fatalf("Failed to create CLOB record with ON CONFLICT: %v", err)
+			}
+		})
+	}
+}
+
+func TestBlobOnConflict(t *testing.T) {
+	type test struct {
+		model any
+		fn    func(model any) error
+	}
+	tests := map[string]test{
+		"OneToManySingle": {
+			model: &BlobOneToManyModel{
+				ID: 1,
+				Children: []BlobChildModel{
+					{
+						Blah: "1",
+						Data: []byte(strings.Repeat("X", 32768)),
+					},
+				},
+			},
+			fn: func(model any) error {
+				return DB.Create(model).Error
+			},
+		},
+		"OneToManyBatch": {
+			model: &BlobOneToManyModel{
+				ID: 1,
+				Children: []BlobChildModel{
+					{
+						Blah: "1",
+						Data: []byte(strings.Repeat("X", 32768)),
+					},
+					{
+						Blah: "2",
+						Data: []byte(strings.Repeat("Y", 3)),
+					},
+				},
+			},
+			fn: func(model any) error {
+				return DB.Create(model).Error
+			},
+		},
+		"Single": {
+			model: []BlobSingleModel{
+				{
+					ID:   1,
+					Data: []byte(strings.Repeat("X", 32768)),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleNotQuiteLOB": {
+			model: []BlobSingleModel{
+				{
+					ID:   1,
+					Data: []byte(strings.Repeat("X", 32767)),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleBatch": {
+			model: []BlobSingleModel{
+				{
+					ID:   1,
+					Data: []byte(strings.Repeat("X", 32768)),
+				},
+				{
+					ID:   2,
+					Data: []byte(strings.Repeat("Y", 3)),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleBatchNotQuiteLOB": {
+			model: []BlobSingleModel{
+				{
+					ID:   1,
+					Data: []byte(strings.Repeat("X", 32767)),
+				},
+				{
+					ID:   2,
+					Data: []byte(strings.Repeat("Y", 3)),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+		"SingleBatchReverse": {
+			model: []BlobSingleModel{
+				{
+					ID:   1,
+					Data: []byte(strings.Repeat("Y", 3)),
+				},
+				{
+					ID:   2,
+					Data: []byte(strings.Repeat("X", 32768)),
+				},
+			},
+			fn: func(model any) error {
+				return DB.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).CreateInBatches(model, 1000).Error
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setupLobTestTables(t)
+			err := tc.fn(tc.model)
+			if err != nil {
+				t.Fatalf("Failed to create BLOB record with ON CONFLICT: %v", err)
+			}
+		})
+	}
+}
+
+func TestClobUpdateOnConflict(t *testing.T) {
+	setupLobTestTables(t)
+	model := []ClobSingleModel{
+		{
+			Blah: "1",
+			Data: strings.Repeat("X", 32768),
+		},
+		{
+			Blah: "2",
+			Data: strings.Repeat("Y", 3),
+		},
+	}
+
+	err := DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(model, 1000).Error
+	if err != nil {
+		t.Fatalf("Failed to create CLOB record with ON CONFLICT: %v", err)
+	}
+	model[1].Data = strings.Repeat("Z", 5000)
+	err = DB.Clauses(clause.OnConflict{UpdateAll: true}).CreateInBatches(model, 1000).Error
+	if err != nil {
+		t.Fatalf("Failed to update CLOB record with ON CONFLICT: %v", err)
+	}
+}


### PR DESCRIPTION
# Description

Inserting strings or byte arrays which exceed the builtin character limit for PLSQL VARCHAR2 variables causes failures. #102 fixes this issue for single inserts/merges. However, in batch inserts where some VARCHAR2 variables have been converted to LOBs and some have not, the subsequent UNION or RETURNING operations will fail due to inconsistent types. 

This change was complicated to fix. Ultimately, it feels like the best thing to do in these scenarios is handle all LOB bulk inserts through PLSQL, where we have the ability to cast input/output as LOB types consistently across an entire column. In order to do that, we have to frontload the real type determination before choosing the code branch. I have attempted to do that in a way that only traverses and casts the createValues object once for efficiency. It will be a net efficiency loss for inserts/merges which do not end up needing PLSQL, though.

As part of testing this change, we found many other deficiencies in the PLSQL merge code path. For example, detecting conflict columns containing a primary key, as well as supporting JSON, UUIDs, boolean, and custom Valuer types in PLSQL. This PR fixes those cases and adds tests for those situations as well.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Numerous unit tests have been added which would fail without the proposed fixes.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules