### PR TITLE
corresponding datatypes need to be the same

### DIFF
--- a/oracle/common.go
+++ b/oracle/common.go
@@ -227,9 +227,6 @@ func convertValue(val interface{}) interface{} {
 
 	// Dereference pointers
 	rv := reflect.ValueOf(val)
-	if rv.Kind() == reflect.Ptr && rv.IsNil() {
-		return nil
-	}
 
 	for rv.Kind() == reflect.Ptr && !rv.IsNil() {
 		rv = rv.Elem()
@@ -259,8 +256,11 @@ func convertValue(val interface{}) interface{} {
 			return ""
 		}
 		return val
-	case bool:
-		if v {
+	case bool, *bool:
+		if isNil {
+			return (*int)(nil)
+		}
+		if v == true {
 			return 1
 		} else {
 			return 0


### PR DESCRIPTION
This is achieved by returning nil types and nil *int pointers for nil *bool This is needed to prevent this error "ORA-01790: expression must have same datatype as corresponding expression"

# Description

When passing in more than one say child and if the child uses pointers there is a potential for the datatypes to get mixed up if one of the child's pointers is nil and the other child's pointer is set. If this occurs the following error is returned.
"ORA-01790: expression must have same datatype as corresponding expression"

It appears a [nil pointer check was added](https://github.com/oracle-samples/gorm-oracle/pull/111) to the convertValue function which will return a nil if a pointer is nil. This causes the original type of the reference to get lost [ (*bool)(nil) was being converted to nil ]. From what I can tell this check was added because nil *bool types where not be persisted correctly. But looking at the convertValue function we don't want to return nil *bool as again the datatypes will get mixed up since the convertValue function is converting bools to int's so we want to return (*int)(nil) for nil *bools to keep the types the same.

The case I primarily ran into was with the usage of an *int in which one of the child's *int's were set and the other was a nil *int. This again caused the datatypes not to match in the corresponding expression. But the same goes for *bool's as well.

Fixes [#114](https://github.com/oracle-samples/gorm-oracle/issues)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Included a corresponding test in pull request to demonstrate issue and verify fix. This test contains *int and *bool and verifies what is stored in the database after insertion. Two joining child records are created. One with nulls and the other with proper values to verify the datatypes are the same for both the child records.

**Test Configuration**:
* Database version: 23ai

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
