### PR TITLE
Tinglwan fix 116

### DIFF
--- a/oracle/common.go
+++ b/oracle/common.go
@@ -44,6 +44,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -707,8 +708,10 @@ func isZeroFor(t reflect.Type, v interface{}) bool {
 func filterFields(s *schema.Schema, predicate func(f *schema.Field) bool) []string {
 	var fields []string
 	for _, f := range s.Fields {
-		if predicate(f) {
-			fields = append(fields, f.DBName)
+		if slices.Contains(s.DBNames, f.DBName) {
+			if predicate(f) {
+				fields = append(fields, f.DBName)
+			}
 		}
 	}
 	return fields

--- a/oracle/common.go
+++ b/oracle/common.go
@@ -97,17 +97,6 @@ func getOracleArrayType(values []any) string {
 	return arrayType
 }
 
-// Helper function to get all column names for a table
-func getAllTableColumns(schema *schema.Schema) []string {
-	var columns []string
-	for _, field := range schema.Fields {
-		if field.DBName != "" {
-			columns = append(columns, field.DBName)
-		}
-	}
-	return columns
-}
-
 // Helper to check if a variable is an OUT parameter
 func isOutParam(v interface{}) bool {
 	_, ok := v.(sql.Out)
@@ -712,4 +701,33 @@ func isZeroFor(t reflect.Type, v interface{}) bool {
 		return !nt.Valid
 	}
 	return false
+}
+
+// generic helper that filters fields based on a predicate
+func filterFields(s *schema.Schema, predicate func(f *schema.Field) bool) []string {
+	var fields []string
+	for _, f := range s.Fields {
+		if predicate(f) {
+			fields = append(fields, f.DBName)
+		}
+	}
+	return fields
+}
+
+func getCreatableFields(s *schema.Schema) []string {
+	return filterFields(s, func(f *schema.Field) bool {
+		return f.Creatable
+	})
+}
+
+func getUpdatableFields(s *schema.Schema) []string {
+	return filterFields(s, func(f *schema.Field) bool {
+		return f.Updatable
+	})
+}
+
+func getMergableFields(s *schema.Schema) []string {
+	return filterFields(s, func(f *schema.Field) bool {
+		return f.Creatable && f.Updatable
+	})
 }

--- a/oracle/create.go
+++ b/oracle/create.go
@@ -960,7 +960,7 @@ func getBulkReturningValues(db *gorm.DB, rowCount int) {
 	}
 
 	// Get all table columns
-	allColumns := db.Statement.Schema.DBNames
+	allColumns := getCreatableFields(db.Statement.Schema)
 
 	// Find the actual starting index of OUT parameters
 	actualStartIndex := -1

--- a/oracle/create.go
+++ b/oracle/create.go
@@ -311,7 +311,7 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 	sanitizeCreateValuesForBulkArrays(db.Statement, &createValues)
 
 	stmt := db.Statement
-	schema := stmt.Schema
+	sch := stmt.Schema
 
 	onConflict, ok := onConflictClause.Expression.(clause.OnConflict)
 	if !ok {
@@ -322,10 +322,10 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 	// Determine conflict columns (use primary key if not specified)
 	conflictColumns := onConflict.Columns
 	if len(conflictColumns) == 0 {
-		if schema == nil || len(schema.PrimaryFields) == 0 {
+		if sch == nil || len(sch.PrimaryFields) == 0 {
 			return
 		}
-		for _, primaryField := range schema.PrimaryFields {
+		for _, primaryField := range sch.PrimaryFields {
 			conflictColumns = append(conflictColumns, clause.Column{Name: primaryField.DBName})
 		}
 	}
@@ -340,7 +340,7 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 	var filteredConflictColumns []clause.Column
 	for _, conflictCol := range conflictColumns {
 		field := stmt.Schema.LookUpField(conflictCol.Name)
-		if valuesColumnMap[strings.ToUpper(conflictCol.Name)] && fieldCanConflict(field, schema) {
+		if valuesColumnMap[strings.ToUpper(conflictCol.Name)] && fieldCanConflict(field, sch) {
 			filteredConflictColumns = append(filteredConflictColumns, conflictCol)
 		}
 	}
@@ -358,7 +358,7 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 
 	// Start PL/SQL block
 	plsqlBuilder.WriteString("DECLARE\n")
-	writeTableRecordCollectionDecl(db, &plsqlBuilder, stmt.Schema.DBNames, stmt.Table)
+	writeTableRecordCollectionDecl(db, &plsqlBuilder, getCreatableFields(stmt.Schema), stmt.Table)
 	plsqlBuilder.WriteString("  l_affected_records t_records;\n")
 
 	// Create array types and variables for each column
@@ -457,9 +457,9 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 			}
 
 			isAutoIncrement := false
-			if schema.PrioritizedPrimaryField != nil &&
-				schema.PrioritizedPrimaryField.AutoIncrement &&
-				strings.EqualFold(schema.PrioritizedPrimaryField.DBName, column.Name) {
+			if sch.PrioritizedPrimaryField != nil &&
+				sch.PrioritizedPrimaryField.AutoIncrement &&
+				strings.EqualFold(sch.PrioritizedPrimaryField.DBName, column.Name) {
 				isAutoIncrement = true
 			} else if stmt.Schema.LookUpField(column.Name).AutoIncrement {
 				isAutoIncrement = true
@@ -563,7 +563,8 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 
 	// Add RETURNING clause with BULK COLLECT INTO
 	plsqlBuilder.WriteString("    RETURNING ")
-	allColumns := getAllTableColumns(schema)
+	allColumns := getMergableFields(sch)
+
 	for i, column := range allColumns {
 		if i > 0 {
 			plsqlBuilder.WriteString(", ")
@@ -576,7 +577,7 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 	outParamIndex := len(stmt.Vars)
 	for rowIdx := 0; rowIdx < len(createValues.Values); rowIdx++ {
 		for _, column := range allColumns {
-			if field := findFieldByDBName(schema, column); field != nil {
+			if field := findFieldByDBName(sch, column); field != nil {
 				if isJSONField(field) {
 					if isRawMessageField(field) {
 						// Column is a BLOB, return raw bytes; no JSON_SERIALIZE
@@ -638,13 +639,13 @@ func buildBulkMergePLSQL(db *gorm.DB, createValues clause.Values, onConflictClau
 // Build PL/SQL block for bulk INSERT only (no conflict handling)
 func buildBulkInsertOnlyPLSQL(db *gorm.DB, createValues clause.Values, bindMap plsqlBindVariableMap) {
 	stmt := db.Statement
-	schema := stmt.Schema
+	sch := stmt.Schema
 
 	var plsqlBuilder strings.Builder
 
 	// Start PL/SQL block
 	plsqlBuilder.WriteString("DECLARE\n")
-	writeTableRecordCollectionDecl(db, &plsqlBuilder, stmt.Schema.DBNames, stmt.Table)
+	writeTableRecordCollectionDecl(db, &plsqlBuilder, getCreatableFields(stmt.Schema), stmt.Table)
 	plsqlBuilder.WriteString("  l_inserted_records t_records;\n")
 
 	// Create array types and variables for each column
@@ -694,7 +695,7 @@ func buildBulkInsertOnlyPLSQL(db *gorm.DB, createValues clause.Values, bindMap p
 
 	// Add RETURNING clause with BULK COLLECT INTO
 	plsqlBuilder.WriteString("    RETURNING ")
-	allColumns := getAllTableColumns(schema)
+	allColumns := getCreatableFields(sch)
 	for i, column := range allColumns {
 		if i > 0 {
 			plsqlBuilder.WriteString(", ")
@@ -711,7 +712,7 @@ func buildBulkInsertOnlyPLSQL(db *gorm.DB, createValues clause.Values, bindMap p
 			db.QuoteTo(&columnBuilder, column)
 			quotedColumn := columnBuilder.String()
 
-			if field := findFieldByDBName(schema, column); field != nil {
+			if field := findFieldByDBName(sch, column); field != nil {
 				if isJSONField(field) {
 					if isRawMessageField(field) {
 						// Column is a BLOB, return raw bytes; no JSON_SERIALIZE
@@ -959,7 +960,7 @@ func getBulkReturningValues(db *gorm.DB, rowCount int) {
 	}
 
 	// Get all table columns
-	allColumns := getAllTableColumns(db.Statement.Schema)
+	allColumns := db.Statement.Schema.DBNames
 
 	// Find the actual starting index of OUT parameters
 	actualStartIndex := -1

--- a/oracle/delete.go
+++ b/oracle/delete.go
@@ -236,15 +236,15 @@ func buildStandardDeleteSQL(db *gorm.DB) {
 // Build PL/SQL block for bulk DELETE with RETURNING
 func buildBulkDeletePLSQL(db *gorm.DB) {
 	stmt := db.Statement
-	schema := stmt.Schema
+	sch := stmt.Schema
 
-	if schema == nil {
+	if sch == nil {
 		db.AddError(fmt.Errorf("schema required for bulk delete with returning"))
 		return
 	}
 
 	// Check if this is a soft delete model and we're not using Unscoped
-	if deletedAtField := schema.LookUpField("deleted_at"); deletedAtField != nil && !stmt.Unscoped {
+	if deletedAtField := sch.LookUpField("deleted_at"); deletedAtField != nil && !stmt.Unscoped {
 		// For soft delete with RETURNING, let GORM handle it normally
 		stmt.Build(stmt.BuildClauses...)
 		return
@@ -273,7 +273,7 @@ func buildBulkDeletePLSQL(db *gorm.DB) {
 
 	// Add RETURNING clause
 	plsqlBuilder.WriteString("\n  RETURNING ")
-	allColumns := getAllTableColumns(schema)
+	allColumns := sch.DBNames
 	for i, column := range allColumns {
 		if i > 0 {
 			plsqlBuilder.WriteString(", ")
@@ -290,7 +290,7 @@ func buildBulkDeletePLSQL(db *gorm.DB) {
 
 	for rowIdx := 0; rowIdx < estimatedRows; rowIdx++ {
 		for _, column := range allColumns {
-			if field := findFieldByDBName(schema, column); field != nil {
+			if field := findFieldByDBName(sch, column); field != nil {
 				if isJSONField(field) {
 					if isRawMessageField(field) {
 						// Column is a BLOB, return raw bytes; no JSON_SERIALIZE
@@ -527,7 +527,7 @@ func getDeleteBulkReturningValues(db *gorm.DB) {
 		return
 	}
 
-	allColumns := getAllTableColumns(db.Statement.Schema)
+	allColumns := db.Statement.Schema.DBNames
 
 	// Count OUT parameters and calculate max rows
 	outParamCount := 0

--- a/oracle/update.go
+++ b/oracle/update.go
@@ -451,9 +451,9 @@ func addPrimaryKeyWhereClauseForUpdate(stmt *gorm.Statement) {
 // Build PL/SQL block for UPDATE with RETURNING
 func buildUpdatePLSQL(db *gorm.DB) {
 	stmt := db.Statement
-	schema := stmt.Schema
+	sch := stmt.Schema
 
-	if schema == nil {
+	if sch == nil {
 		db.AddError(fmt.Errorf("schema required for update with returning"))
 		return
 	}
@@ -477,7 +477,7 @@ func buildUpdatePLSQL(db *gorm.DB) {
 
 	// Start PL/SQL block
 	plsqlBuilder.WriteString("DECLARE\n")
-	writeTableRecordCollectionDecl(db, &plsqlBuilder, stmt.Schema.DBNames, stmt.Table)
+	writeTableRecordCollectionDecl(db, &plsqlBuilder, getUpdatableFields(stmt.Schema), stmt.Table)
 	plsqlBuilder.WriteString("  l_updated_records t_records;\n")
 	plsqlBuilder.WriteString("BEGIN\n")
 
@@ -524,7 +524,7 @@ func buildUpdatePLSQL(db *gorm.DB) {
 
 	// Add RETURNING clause
 	plsqlBuilder.WriteString("\n  RETURNING ")
-	allColumns := getAllTableColumns(schema)
+	allColumns := getUpdatableFields(sch)
 	for i, column := range allColumns {
 		if i > 0 {
 			plsqlBuilder.WriteString(", ")
@@ -541,7 +541,7 @@ func buildUpdatePLSQL(db *gorm.DB) {
 	// First, create all OUT parameters
 	for rowIdx := 0; rowIdx < estimatedRows; rowIdx++ {
 		for _, column := range allColumns {
-			field := findFieldByDBName(schema, column)
+			field := findFieldByDBName(sch, column)
 			if field != nil {
 				var dest interface{}
 				if isJSONField(field) {
@@ -563,7 +563,7 @@ func buildUpdatePLSQL(db *gorm.DB) {
 	// Then, generate PL/SQL assignments with correct parameter indices
 	for rowIdx := 0; rowIdx < estimatedRows; rowIdx++ {
 		for colIdx, column := range allColumns {
-			field := findFieldByDBName(schema, column)
+			field := findFieldByDBName(sch, column)
 			if field != nil {
 				paramIndex := outParamStartIndex + (rowIdx * len(allColumns)) + colIdx + 1
 
@@ -671,7 +671,7 @@ func getUpdateReturningValues(db *gorm.DB) {
 		return
 	}
 
-	allColumns := getAllTableColumns(db.Statement.Schema)
+	allColumns := getUpdatableFields(db.Statement.Schema)
 
 	if len(allColumns) == 0 {
 		return

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -50,6 +50,7 @@ import (
 
 	"time"
 
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/utils/tests"
@@ -1001,4 +1002,45 @@ func TestCreateChildrenWithMixedPointers(t *testing.T) {
 		t.Fatalf("expected second child's has to be true, got %v", resultParents[0].Children[1].BoolPtr)
 	}
 
+}
+
+func TestCreateReadOnlyJson(t *testing.T) {
+	type record struct {
+		ID            string         `gorm:"column:child_id;primaryKey;type:varchar(36)"`
+		ReadOnlyField string         `gorm:"->;-:migration;column:read_only_field;type:varchar(100)"`
+		JsonTypeField datatypes.JSON `gorm:"column:json_type_field;type:json"`
+	}
+
+	json := datatypes.JSON(fmt.Sprintf(`{"key":"%s"}`, strings.Repeat("x", 4000)))
+	records := []record{
+		{
+			ID:            "1",
+			JsonTypeField: json,
+		},
+		{
+			ID: "2",
+		},
+	}
+
+	DB.Migrator().DropTable(&record{})
+	err := DB.AutoMigrate(&record{})
+	if err != nil {
+		t.Fatalf("errors happened with migrate: %v", err)
+	}
+
+	err = DB.Model(&records).Create(&records).Error
+	if err != nil {
+		t.Fatalf("errors happened when create: %v", err)
+	}
+
+	// verify records are created
+	var results []record
+	err = DB.Find(&results).Error
+	if err != nil {
+		t.Fatalf("errors happened when querying after create: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 1 parent, got %d", len(results))
+	}
 }

--- a/tests/create_test.go
+++ b/tests/create_test.go
@@ -1004,18 +1004,22 @@ func TestCreateChildrenWithMixedPointers(t *testing.T) {
 
 }
 
+// Fixes Issue #116
 func TestCreateReadOnlyJson(t *testing.T) {
 	type record struct {
-		ID            string         `gorm:"column:child_id;primaryKey;type:varchar(36)"`
-		ReadOnlyField string         `gorm:"->;-:migration;column:read_only_field;type:varchar(100)"`
-		JsonTypeField datatypes.JSON `gorm:"column:json_type_field;type:json"`
+		ID             string         `gorm:"column:child_id;primaryKey;type:varchar(36)"`
+		ReadOnlyField  string         `gorm:"->;-:migration;column:read_only_field;type:varchar(100)"`
+		JsonTypeField  datatypes.JSON `gorm:"column:json_type_field;type:json"`
+		JsonTypeField2 AttributeMap   `gorm:"column:json_type_field2;type:json"`
 	}
 
 	json := datatypes.JSON(fmt.Sprintf(`{"key":"%s"}`, strings.Repeat("x", 4000)))
+	attributeMapJSON := AttributeMap{"key": strings.Repeat("x", 4000)}
 	records := []record{
 		{
-			ID:            "1",
-			JsonTypeField: json,
+			ID:             "1",
+			JsonTypeField:  json,
+			JsonTypeField2: attributeMapJSON,
 		},
 		{
 			ID: "2",


### PR DESCRIPTION
# Description

Filters out fields (e.g. read-only field) that should not be included in bulk INSERT, UPDATE, or MERGE operations when generating the PL/SQL blocks.

Fixes #116 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TestCreateReadOnlyJson
