### PR TITLE
fix(query): convert bool bind vars in BeforeQuery

### DIFF
--- a/oracle/query.go
+++ b/oracle/query.go
@@ -55,14 +55,19 @@ import (
 var tableRegexp = regexp.MustCompile(`^"(\w+)"\s+"?(\w+)"?$`)
 
 func BeforeQuery(db *gorm.DB) {
-	if db == nil || db.Statement == nil || db.Statement.TableExpr == nil {
+	if db == nil || db.Statement == nil {
 		return
 	}
-	name := db.Statement.TableExpr.SQL
-	if strings.Contains(name, " ") || strings.Contains(name, "`") {
-		if results := tableRegexp.FindStringSubmatch(name); len(results) == 3 {
-			db.Statement.Table = results[2]
+	if db.Statement.TableExpr != nil {
+		name := db.Statement.TableExpr.SQL
+		if strings.Contains(name, " ") || strings.Contains(name, "`") {
+			if results := tableRegexp.FindStringSubmatch(name); len(results) == 3 {
+				db.Statement.Table = results[2]
+			}
 		}
+	}
+	for i, val := range db.Statement.Vars {
+		db.Statement.Vars[i] = convertValue(val)
 	}
 }
 

--- a/oracle/query_test.go
+++ b/oracle/query_test.go
@@ -1,0 +1,56 @@
+package oracle
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestBeforeQuery_ConvertsVarsAndHandlesAlias(t *testing.T) {
+	vTrue := true
+	vFalse := false
+
+	stmt := &gorm.Statement{
+		TableExpr: &clause.Expr{SQL: `"users" "u"`},
+		Vars:      []interface{}{true, false, &vTrue, &vFalse, (*bool)(nil), "name", 42},
+	}
+
+	BeforeQuery(&gorm.DB{Statement: stmt})
+
+	if stmt.Table != "u" {
+		t.Fatalf("expected alias table name %q, got %q", "u", stmt.Table)
+	}
+
+	for i, expected := range []int{1, 0, 1, 0} {
+		got, ok := stmt.Vars[i].(int)
+		if !ok || got != expected {
+			t.Fatalf("expected vars[%d] to be int(%d), got %#v", i, expected, stmt.Vars[i])
+		}
+	}
+
+	if v, ok := stmt.Vars[4].(*int); !ok || v != nil {
+		t.Fatalf("expected vars[4] to be (*int)(nil), got %#v", stmt.Vars[4])
+	}
+
+	if got, ok := stmt.Vars[5].(string); !ok || got != "name" {
+		t.Fatalf("expected vars[5] to stay string %q, got %#v", "name", stmt.Vars[5])
+	}
+
+	if got, ok := stmt.Vars[6].(int); !ok || got != 42 {
+		t.Fatalf("expected vars[6] to stay int(42), got %#v", stmt.Vars[6])
+	}
+}
+
+func TestBeforeQuery_ConvertsVarsWithoutTableExpr(t *testing.T) {
+	stmt := &gorm.Statement{
+		Vars: []interface{}{true},
+	}
+
+	BeforeQuery(&gorm.DB{Statement: stmt})
+
+	if got, ok := stmt.Vars[0].(int); !ok || got != 1 {
+		t.Fatalf("expected vars[0] to be int(1), got %#v", stmt.Vars[0])
+	}
+}
+


### PR DESCRIPTION
# Description

  BeforeQuery in query.go did not convert bind variables with convertValue(), unlike create/update/delete callbacks.
  This caused Oracle bind type mismatches for boolean filters (for example WHERE is_active = ? with true) against NUMBER(1) columns, producing ORA-00932:
  expected NUMBER got BOOLEAN.

  This change updates BeforeQuery to convert all db.Statement.Vars via convertValue(), while preserving existing table alias handling.

  Also added unit tests to validate:

  - bool and *bool query vars are converted to 1/0 (and nil pointer handling is preserved)
  - conversion still runs even when TableExpr is nil

  Dependencies: none.

  Fixes # (issue)

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

  # How Has This Been Tested?

  Ran:

  go test ./oracle -run TestBeforeQuery -count=1

  Added tests:

  - TestBeforeQuery_ConvertsVarsAndHandlesAlias
  - TestBeforeQuery_ConvertsVarsWithoutTableExpr
  - [x] Test A
  - [ ] Test B

  Test Configuration:

  - Database version: N/A (unit test; no DB instance required)

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing unit tests pass locally with my changes