### PR TITLE
fix(query): set uuid for slice of results

### DIFF
--- a/oracle/query.go
+++ b/oracle/query.go
@@ -72,19 +72,10 @@ func BeforeQuery(db *gorm.DB) {
 }
 
 func AfterQuery(db *gorm.DB) {
-	if db == nil || db.Statement == nil || db.Statement.Schema == nil {
+	if db == nil || db.Statement == nil {
 		return
 	}
-	destinationStruct := reflect.ValueOf(db.Statement.Dest)
-	for _, field := range db.Statement.Schema.Fields {
-		if field.DataType == "uuid" {
-			uuidDestField := reflect.Indirect(destinationStruct).FieldByName(field.Name)
-			if uuidDestField.Kind() == reflect.Ptr && !uuidDestField.IsNil() && uuidDestField.Elem().IsZero() {
-				// NULL UUIDs should be returned as nil if the field is a pointer type (as opposed to all-zero value)
-				field.Set(db.Statement.Context, destinationStruct, nil)
-			}
-		}
-	}
+	fixStructsWithZeroUUIDPtrs(db.Statement)
 }
 
 // MismatchedCaseHandler handles Oracle case insensitivity for unquoted identifiers.
@@ -169,4 +160,41 @@ func addNestedFieldMappings(columnMapping map[string]string, aliasName string, j
 		nestedName := utils.NestedRelationName(aliasName, dbName)
 		columnMapping[strings.ToUpper(nestedName)] = nestedName
 	}
+}
+
+// fixStructsWithZeroUUIDPtrs replaces any pointers to zero-value UUIDs in the current statement's destination struct(s) with nil.
+func fixStructsWithZeroUUIDPtrs(stmt *gorm.Statement) {
+	if stmt == nil || stmt.Schema == nil {
+		return
+	}
+	var processValue func(value reflect.Value)
+	processValue = func(value reflect.Value) {
+		// If it's a pointer, dereference it to get to the actual value for the kind checking.
+		// We will set the field on the pointer if it's addressable, or create a new pointer if not.
+		value = reflect.Indirect(value)
+
+		// We may get a struct, slice, or array depending on the destination's type.
+		switch value.Kind() {
+		case reflect.Slice, reflect.Array:
+			for i := 0; i < value.Len(); i++ {
+				processValue(value.Index(i))
+			}
+		case reflect.Struct:
+			var valuePtr reflect.Value
+			if !value.CanAddr() {
+				return
+			}
+			valuePtr = value.Addr()
+
+			for _, field := range stmt.Schema.Fields {
+				if field.DataType == "uuid" {
+					fieldValue := value.FieldByName(field.Name)
+					if fieldValue.Kind() == reflect.Ptr && !fieldValue.IsNil() && fieldValue.Elem().IsZero() {
+						field.Set(stmt.Context, valuePtr, nil)
+					}
+				}
+			}
+		}
+	}
+	processValue(reflect.ValueOf(stmt.Dest))
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/oracle-samples/gorm-oracle/tests
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/godror/godror v0.50.0

--- a/tests/uuid_after_query_test.go
+++ b/tests/uuid_after_query_test.go
@@ -40,6 +40,7 @@ package tests
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -70,7 +71,12 @@ type afterQueryNonUUIDModel struct {
 // construct minimal *gorm.DB with dest struct bound on statement
 func buildDBForAfterQuery(t *testing.T, dest interface{}) *gorm.DB {
 	t.Helper()
-	s, err := schema.Parse(dest, &sync.Map{}, schema.NamingStrategy{})
+	destForSchema := dest
+	kind := reflect.Indirect(reflect.ValueOf(dest)).Kind()
+	if kind == reflect.Slice || kind == reflect.Array {
+		destForSchema = reflect.Indirect(reflect.ValueOf(dest)).Index(0).Interface()
+	}
+	s, err := schema.Parse(destForSchema, &sync.Map{}, schema.NamingStrategy{})
 	if err != nil {
 		t.Fatalf("schema.Parse failed: %v", err)
 	}
@@ -101,6 +107,27 @@ func TestAfterQuery_UUIDPtr_ZeroUUID_SetToNil(t *testing.T) {
 
 	if dest.UUID != nil {
 		t.Errorf("expected UUID to be nil for a zero UUID value, got %v", dest.UUID)
+	}
+}
+
+func TestAfterQuery_UUIDPtr_ZeroUUID_SetToNil_Slice(t *testing.T) {
+	zeroUUID := uuid.UUID{} // 00000000-0000-0000-0000-000000000000 is what gorm reflection gives back when Oracle holds NULL
+	dest := []*afterQueryUUIDPtrModel{{UUID: &zeroUUID}, {UUID: &zeroUUID}}
+	oracle.AfterQuery(buildDBForAfterQuery(t, dest))
+
+	if (dest)[0].UUID != nil || (dest)[1].UUID != nil {
+		t.Errorf("expected UUID to be nil for a zero UUID value, got %v and %v", (dest)[0].UUID, (dest)[1].UUID)
+	}
+}
+
+// Ensure it works when the dest is an array of structs as well
+func TestAfterQuery_UUIDPtr_ZeroUUID_SetToNil_Array(t *testing.T) {
+	zeroUUID := uuid.UUID{} // 00000000-0000-0000-0000-000000000000 is what gorm reflection gives back when Oracle holds NULL
+	dest := [2]*afterQueryUUIDPtrModel{{UUID: &zeroUUID}, {UUID: &zeroUUID}}
+	oracle.AfterQuery(buildDBForAfterQuery(t, dest))
+
+	if dest[0].UUID != nil || dest[1].UUID != nil {
+		t.Errorf("expected UUID to be nil for a zero UUID value, got %v and %v", dest[0].UUID, dest[1].UUID)
 	}
 }
 


### PR DESCRIPTION
# Description

When we added the fix to set pointers to UUIDs with zero values as nil, it introduced a bug if the destination is a slice or array rather than a struct. In those cases a panic is caused due to them not having the `FieldByName` method.

Fixes # 131

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Added unit tests that cover these cases.
* Manually created a query that duplicated the issue and verified it no longer crashes.
* Update the software where the bug was discovered to use this branch and verified it is resolved.
* Manually created a query that duplicates the original UUID issue to verify that it still fixes the original bug.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
